### PR TITLE
Fix 404 for images/errorArrow.png in distribution build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -185,6 +185,7 @@ module.exports = function (grunt) {
       },
       dist: {
         options: {
+          cssDir: '<%= yeoman.dist %>/styles',
           generatedImagesDir: '<%= yeoman.dist %>/images/generated'
         }
       },


### PR DESCRIPTION
Whenever I would run `grunt build` and then serve the application in _dist/_, I would get a 404 for `{my serving path}/.tmp/images/errorArrow.png`.  I tracked this down to a missing `compass:dist` option in _Gruntfile.js_.
