### PR TITLE
changing  qparam name from `url` to `import`

### DIFF
--- a/app/scripts/controllers/main.js
+++ b/app/scripts/controllers/main.js
@@ -16,8 +16,8 @@ PhonicsApp.controller('MainCtrl', function MainCtrl($rootScope, $stateParams, Ed
       var url;
 
       // If there is a url provided, override the storage with that URL
-      if ($stateParams.url) {
-        url = $stateParams.url;
+      if ($stateParams.import) {
+        url = $stateParams.import;
 
       // If there is no saved YAML either, load the default example
       } else if (!yaml) {

--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -5,7 +5,7 @@ PhonicsApp.config(function Router($compileProvider, $stateProvider, $urlRouterPr
 
   $stateProvider
   .state('home', {
-    url: '?url',
+    url: '?import',
     views: {
       '': {
         templateUrl: 'views/main.html',


### PR DESCRIPTION
`url` is ambiguous as to what the qparam does. Will still need to consider stripping the qparam after it has been processed, as page reloads would re-import.
