### PR TITLE
This commit fixes #159 the text color of select items in the modal box

### DIFF
--- a/app/styles/components/modal.scss
+++ b/app/styles/components/modal.scss
@@ -36,6 +36,10 @@
     label {
       margin-bottom: .5em;
     }
+
+    select {
+      color: #000000; // 1
+    }
   }
 
   .modal-footer {


### PR DESCRIPTION
Now the select box items will be black:

Before:
![Imgur](http://i.imgur.com/VawggeB.png)
After:
![Imgur](http://i.imgur.com/HMyigQy.png)
