### PR TITLE
[Enhancement] Dockering the application to fix #179.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+###
+# Swagger-editor runtime dependency with all the needed dependencies installed.
+# This dependency will automatically call "grunt serve" after the installation
+# on this layer is performed.
+###
+FROM marcellodesales/swagger-editor-runtime
+MAINTAINER Marcello_deSales@intuit.com
+
+# The default port of the application.
+EXPOSE 9000
+
+# Runs all the installation of the current dependencies at this image's
+# build time, so that is guarantees that all the dependencies are installed.
+RUN npm install && bower --allow-root --save --force-latest install

--- a/grunt/connect.js
+++ b/grunt/connect.js
@@ -2,7 +2,7 @@ module.exports = {
   options: {
     port: 9000,
     // Change this to '0.0.0.0' to access the server from outside.
-    hostname: 'localhost',
+    hostname: '0.0.0.0',
     livereload: 35729
   },
   livereload: {


### PR DESCRIPTION
This commit adds initial implementation for deploying the current
code in a "Dockerized" container. That is, deploying the source-code
in a Docker container and being able to run it from anywhere with
the Docker runtime installed.
-   new file:   Dockerfile
- The Dockerfile containing the runtime installation process to the
  npm and bower dependencies.
- The parent Docker image will be already contain all the dependencies
  that allows users to run the current code.
- Exposing the default port 9000.
-   modified:   grunt/connect.js
- Changing the IP address from local to 0.0.0.0 in order to be able
  to be called from outside the container.
