### PR TITLE
Add full steps for Dockerfile and a .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+node_modules
+app/bower_components
+.*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ dist/
 node_modules
 app/bower_components
 *.sublime-workspace
+.*.swp
 buttons.diff

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,29 @@
 ###
-# Swagger-editor runtime dependency with all the needed dependencies installed.
-# This dependency will automatically call "grunt serve" after the installation
-# on this layer is performed.
+# swagger-editor - https://github.com/wordnik/swagger-editor/
+#
+# Run the swagger-editor service on port 9000
 ###
-FROM marcellodesales/swagger-editor-runtime
+
+FROM    ubuntu:14.04
 MAINTAINER Marcello_deSales@intuit.com
 
-# The default port of the application.
-EXPOSE 9000
+ENV     DEBIAN_FRONTEND noninteractive
 
-# Runs all the installation of the current dependencies at this image's
-# build time, so that is guarantees that all the dependencies are installed.
-RUN npm install && bower --allow-root --save --force-latest install
+RUN     apt-get update && apt-get install -y git npm nodejs
+RUN     ln -s /usr/bin/nodejs /usr/local/bin/node
+
+WORKDIR /runtime
+ADD     package.json    /runtime/package.json
+RUN     npm install
+RUN     npm install -g bower grunt-cli
+
+
+ADD     bower.json      /runtime/bower.json
+ADD     .bowerrc        /runtime/.bowerrc
+RUN     bower --allow-root install
+
+ADD     .   /runtime
+
+# The default port of the application
+EXPOSE  9000
+CMD     grunt serve

--- a/README.md
+++ b/README.md
@@ -70,23 +70,27 @@ Please do not touch `gh-pages` branch manually!
 
 ### Docker Container
 
-If you are familiar with [Docker](https://www.docker.com/), you can build a Docker image of the current code using the project's Dockerfile.
+If you are familiar with [Docker](https://www.docker.com/), you can build a
+Docker image of the current code using the project's Dockerfile. From the root
+of the repo run:
 
 ```
-sudo docker build -t my-swagger-editor ~/github/swagger-editor
+sudo docker build -t my-swagger-editor .
 ```
 
-Where ~/github/swagger-editor is the path to the clone of this repo and my-swagger-editor is the tag for the image.
+Where `my-swagger-editor` is the tag for the image.
 
-In order to run the built image as a Docker container, use the following:
+To run the image as a Docker container, use the following:
 
 ```
-sudo docker run -ti -p 80:9000 my-swagger-editor
+sudo docker run -ti -p 8080:9000 my-swagger-editor
 ```
 
-Where 80 is the port in the host and you can change to your environment.
+And open [http://localhost:8080](http://localhost:8080) in your browser. Port
+8080 in this example may be any available port.
 
-If you want to know more about the process to build the images, go to the [Docker Node.js Sample tutorial](https://docs.docker.com/examples/nodejs_web_app/).
+If you want to know more about the process to build the images, go to the
+[Docker Node.js Sample tutorial](https://docs.docker.com/examples/nodejs_web_app/).
  
 ### Contributing
 File issues in GitHub's to report bugs or issue a pull request.


### PR DESCRIPTION
Adds to #179 by including all steps in the `Dockerfile` (previously they were in a base image with no way to build that image).

I've also added a `.dockerignore` so that unnecessary files will not be pulled in while making the image.
