### PR TITLE
Request YAML & cope with JSON responses

### DIFF
--- a/app/scripts/services/fileloader.js
+++ b/app/scripts/services/fileloader.js
@@ -47,9 +47,9 @@ PhonicsApp.service('FileLoader', function FileLoader($http) {
       method: 'GET',
       url: url,
       headers: {
-        'Accept': 'application/x-yaml,text/yaml,application/json,*/*'}
+        accept: 'application/x-yaml,text/yaml,application/json,*/*'
       }
-    ).then(function (resp) {
+    }).then(function (resp) {
       if (angular.isObject(resp.data)) {
         return jsyaml.dump(resp.data);
       } else {


### PR DESCRIPTION
When loading Swagger docs from a remote location the app now requests YAML, then JSON, then anything else (in that order) via the http `Accept` header so that sites with the ability to send multiple formats return the correct one.

It can now also cope with JSON being returned (which is automatically converted into an object by `$http.get`).
