### PR TITLE
fix link. + 'not yet been documented'

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Valid Swagger JSON descriptions can then be generated and used with the full Swa
 To understand how it works, you should [try the live demo](http://editor.swagger.io/#/edit)!
 
 ## YAML Syntax
-YAML became a first-class citizen as part of the Swagger 2.0 working group process. Documenation for the YAML syntax will become part of the documentation of the [Swagger 2.0 spec](https://github.com/reverb/swagger-spec).
+YAML became a first-class citizen as part of the Swagger 2.0 working group process, however it has not yet been documented in the [Swagger Spec](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md). The editor opens with an example YAML file. For some other examples see '[Creating Swagger JSON from YAML files](https://github.com/swagger-api/swagger-codegen/wiki/Creating-Swagger-JSON-from-YAML-files)'
 
 ![Screenshot of the Swagger Editor](app/images/screenshot.png "Designing an API with the Swagger Editor")
 


### PR DESCRIPTION
Currently this links to a doc which says it's out-of-date and links to the current 2.0 spec doc, so fix that link (although no mention of YAML there yet!). Also link 'Creating Swagger JSON from YAML files' which has some examples
