### PR TITLE
Fix schema-form.js 404 not found error.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -52,7 +52,7 @@
     <script src="bower_components/json-refs/browser/json-refs.js"></script>
     <script src="bower_components/swagger-tools/browser/swagger-tools.js"></script>
 
-    <script src="bower_components/angular-schema-form/dist/schema-form.js"></script>
+    <script src="bower_components/angular-schema-form/dist/schema-form.min.js"></script>
     <script src="bower_components/angular-schema-form/dist/bootstrap-decorator.min.js"></script>
     <script src="bower_components/harmony-collections/harmony-collections.js"></script>
     <!-- endbuild -->

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -46,7 +46,7 @@ module.exports = function(config) {
       'app/bower_components/traverse/traverse.js',
       'app/bower_components/swagger-tools/browser/swagger-tools.js',
       'app/bower_components/objectpath/lib/ObjectPath.js',
-      'app/bower_components/angular-schema-form/dist/schema-form.js',
+      'app/bower_components/angular-schema-form/dist/schema-form.min.js',
       'app/bower_components/angular-schema-form/dist/bootstrap-decorator.min.js',
       'bower_components/tv4/tv4.js',
       'app/scripts/*.js',


### PR DESCRIPTION
The file was not found in path "swagger-editor\app\bower_components\angular-schema-form\dist" but found a file named "schema-form.min.js",
So I guess we should be to use it.