### PR TITLE
Fix for #302: tryoutoperation falls now back to root security object

### DIFF
--- a/app/scripts/directives/tryoperation.js
+++ b/app/scripts/directives/tryoperation.js
@@ -362,6 +362,10 @@ SwaggerEditor.controller('TryOperation', function ($scope, formdataFilter,
       return none.concat($scope.operation.security.map(function (security) {
         return Object.keys(security)[0];
       }));
+    } else if (Array.isArray($scope.specs.security)) {
+      return none.concat($scope.specs.security.map(function (security) {
+        return Object.keys(security)[0];
+      }));
     }
     return none;
   };

--- a/app/scripts/directives/tryoperation.js
+++ b/app/scripts/directives/tryoperation.js
@@ -356,7 +356,7 @@ SwaggerEditor.controller('TryOperation', function ($scope, formdataFilter,
     return parseHeaders(xhr.getAllResponseHeaders());
   }
 
-  $scope.getSecuirtyOptions = function () {
+  $scope.getSecurityOptions = function () {
     var none = [NONE_SECURITY];
     if (Array.isArray($scope.operation.security)) {
       return none.concat($scope.operation.security.map(function (security) {

--- a/app/templates/try-operation.html
+++ b/app/templates/try-operation.html
@@ -39,8 +39,8 @@
         <tr>
           <td><label>Security</label></td>
           <td>
-            <select ng-model="$parent.selectedSecurity" ng-init="$parent.selectedSecurity = getSecuirtyOptions()[0]">
-              <option ng-repeat="option in getSecuirtyOptions()" value="{{option}}" ng-disabled="!$parent.securityIsAuthenticated(option)">
+            <select ng-model="$parent.selectedSecurity" ng-init="$parent.selectedSecurity = getSecurityOptions()[0]">
+              <option ng-repeat="option in getSecurityOptions()" value="{{option}}" ng-disabled="!$parent.securityIsAuthenticated(option)">
                 {{option + (!$parent.securityIsAuthenticated(option) ? ' (Not authenticated)' : '')}}
               </option>
             </select>


### PR DESCRIPTION
After checking for an existing security property in the operation, it also checks now for the existence of the root level security object and use it as fallback if needed. This way it still allows the operation to overwrite the root with just an empty array, 

This fixes Issue #302 but not #318.