### PR TITLE
Move to a single tracker for swagger

### DIFF
--- a/app/config/defaults.json
+++ b/app/config/defaults.json
@@ -7,7 +7,7 @@
   },
   "analytics": {
     "google": {
-      "id": "UA-51231036-2"
+      "id": "UA-51231036-1"
     }
   },
   "disableCodeGen": true,


### PR DESCRIPTION
No obvious reason to bifurcate the analytics, so switching to the original ID.