### PR TITLE
Use PORT environmental variable for serve task

### DIFF
--- a/grunt/connect.js
+++ b/grunt/connect.js
@@ -1,14 +1,16 @@
 'use strict';
 
+var port = process.env.PORT || 9000;
+
 module.exports = {
   options: {
-    port: 9000,
+    port: port,
     hostname: 'localhost',
     livereload: 35729
   },
   livereload: {
     options: {
-      open: 'http://localhost:9000/#/edit',
+      open: 'http://localhost:' + port + '/#/edit',
       base: [
         '.tmp',
         'app'


### PR DESCRIPTION
In my environment, other development server uses port 9000. It's useful to change the port with env var.