### PR TITLE
Update git clone URL to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ http://editor.swagger.io/#/edit?import=http://generator.wordnik.com/online/api/s
 Make sure you have [Node.js](http://nodejs.org/) installed. 
 
 ```shell
-git clone git@github.com:swagger-api/swagger-editor.git
+git clone https://github.com/swagger-api/swagger-editor.git
 cd swagger-editor
 npm start
 ```


### PR DESCRIPTION
GitHub recommends changing to https. See GitHub FAQ "Which remote URL should I use?" at https://help.github.com/articles/which-remote-url-should-i-use/

(My particular need for this is because I password protect ssh git credentials, which means GitHub prompts me for a password when I clone using ssh git instead of HTTPS; it is very helpful for scripted installations to have HTTPS, because there's no need for a password prompt)

