### PR TITLE
Disable grunt livereload for dist goal and speed container start time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ ADD     .   /runtime
 
 # The default port of the application
 EXPOSE  80
-CMD     grunt build; grunt connect:dist
+CMD     grunt serve:dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,9 @@ RUN     npm install -g bower grunt-cli
 ADD     bower.json      /runtime/bower.json
 ADD     .bowerrc        /runtime/.bowerrc
 RUN     bower --allow-root install
-RUN 	grunt build
-
 
 ADD     .   /runtime
+RUN 	grunt build
 
 # The default port of the application
 EXPOSE  80

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,11 @@ RUN     npm install -g bower grunt-cli
 ADD     bower.json      /runtime/bower.json
 ADD     .bowerrc        /runtime/.bowerrc
 RUN     bower --allow-root install
+RUN 	grunt build
+
 
 ADD     .   /runtime
 
 # The default port of the application
 EXPOSE  80
-CMD     grunt serve:dist
+CMD     grunt connect:dist

--- a/grunt/connect.js
+++ b/grunt/connect.js
@@ -32,7 +32,8 @@ module.exports = {
       keepalive: true,
       base: 'dist',
       port: 80,
-      hostname: '0.0.0.0'
+      hostname: '0.0.0.0',
+      livereload: false
     }
   }
 };


### PR DESCRIPTION
Disable livereload for dist goal as this is not necessary when deploying the application outside of developments, and can lead to timeouts of the livereload request in production(interface *will take a few minutes to show up).

Also Docker command executed would always build at runtime, which is can be done earlier at docker build time, hence speeding up the container starting time. 