### PR TITLE
Added less placeholders so wiredep doesn't remove bootstrap less/css …

### DIFF
--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -2,10 +2,13 @@
 
 // automatically imported using grunt wiredep task. Do not add anything between comments below
 // bower:css
-@import (less) "../bower_components/bootstrap/dist/css/bootstrap.css";
 @import (less) "../bower_components/json-formatter/dist/json-formatter.css";
 @import (less) "../bower_components/angular-ui-layout/ui-layout.css";
 @import (less) "../bower_components/json-schema-view/dist/json-schema-view.css";
+// endbower
+
+// bower:less
+@import "../bower_components/bootstrap/less/bootstrap.less";
 // endbower
 
 @import "fonts";


### PR DESCRIPTION
…dependency during build Fixes #498 

In bootstrap's bower.json file, the "main" property includes less/bootstrap.less instead of dist/bootstrap.css, but app/styles/main.less didn't include any placeholders for .less files. This caused wiredep to delete the bootstrap.css file from main.less, causing the mis-aligned menu referenced in #498. Adding the less placeholders fixed the build for me.