### PR TITLE
Correct 'Authorization' to 'Token' URL

### DIFF
--- a/app/templates/security.html
+++ b/app/templates/security.html
@@ -41,7 +41,7 @@
               <td><a target="_blank" href="{{securityDefinition.authorizationUrl}}">{{securityDefinition.authorizationUrl}}</a></td>
             </tr>
             <tr ng-if="securityDefinition.tokenUrl">
-              <td>Authorization URL</td>
+              <td>Token URL</td>
               <td><a target="_blank" href="{{securityDefinition.tokenUrl}}">{{securityDefinition.tokenUrl}}</a></td>
             </tr>
           </tbody>


### PR DESCRIPTION
security.html has duplicate Authorization URL titles, the second one is supposed to be Token URL.