### PR TITLE
Enable "XMLHttpRequest.withCredentials" option

### DIFF
--- a/app/scripts/directives/tryoperation.js
+++ b/app/scripts/directives/tryoperation.js
@@ -809,7 +809,10 @@ SwaggerEditor.controller('TryOperation', function ($scope, formdataFilter,
       type: $scope.operationName,
       headers: _.omit($scope.getHeaders(), omitHeaders),
       data: $scope.getRequestBody(),
-      contentType: $scope.contentType
+      contentType: $scope.contentType,
+      xhrFields: {
+        withCredentials: true
+      }
     })
 
     .fail(function (jqXHR, textStatus, errorThrown) {


### PR DESCRIPTION
Makes cross-site Access-Control requests send cookies as well.