### PR TITLE
Fixing issue #684

### DIFF
--- a/app/scripts/directives/tryoperation.js
+++ b/app/scripts/directives/tryoperation.js
@@ -482,10 +482,16 @@ SwaggerEditor.controller('TryOperation', function ($scope, formdataFilter,
     var required = $scope.requestSchema.properties.parameters
       .properties[param.name].required === true;
 
-    // if this parameter is not provided (empty string value) by user and it's
-    // not required, move to next parameter without adding this one to the hash
-    if (param.type === 'string' && paramValue === '' && !required) {
-      return hash;
+    // if this parameter is not provided (undefined or empty string value) by
+    // user and it's not required, move to next parameter without adding
+    // this one to the hash
+    if (!required) {
+      if (paramValue === undefined) {
+        return hash;
+      }
+      if (param.type === 'string' && paramValue === '') {
+        return hash;
+      }
     }
 
     hash[param.name] = $scope.requestModel.parameters[param.name];


### PR DESCRIPTION
Proposition for solving issue #684

What was the problem? When a query parameter (let's say `foo`) was defined as an optional string, it would show up nevertheless in the url (e.g. `/route?foo=&bar=stuff`)

The cause was in the following piece of code being totally irrelevant in the `hashifyParams` function in `tryoperations.js`
```js
    // if this parameter is not provided (empty string value) by user and it's
    // not required, move to next parameter without adding this one to the hash
    if (param.type === 'string' && paramValue === '' && !required) {
      return hash;
    }
```
because for some reason the parameter's value becomes `undefined`.

As I could not figure out the reason why this would happen, and given my limited knowledge, I just went for this quick-and-dirty fix: just adding a check for the case when `paramValue` is `undefined`.

Maybe this is connected to the fact that a `0` input value for a required numeric parameter gets also undefined, causing a "Property must be set" error?