### PR TITLE
Update sway-worker to 1.8.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -49,7 +49,7 @@
     }
   },
   "devDependencies": {
-    "sway-worker": "~1.7.0",
+    "sway-worker": "~1.8.0",
     "angular-mocks": "~1.4.2"
   }
 }


### PR DESCRIPTION
I had problems getting the swagger-editor to run after a recent rebuild of my Docker container.
This is the issue I was getting:

![swagger-editor](https://cloud.githubusercontent.com/assets/14321/10978523/c8cca18e-83f7-11e5-803d-f692c9a49cc0.png)

Updating to sway-worker 1.8.0 fixed it apparently.