### PR TITLE
[preview] Render response examples

### DIFF
--- a/app/scripts/directives/operation.js
+++ b/app/scripts/directives/operation.js
@@ -80,7 +80,7 @@ SwaggerEditor.directive('swaggerOperation', function (defaults) {
        * Returns true if the operation responses has at least one response with
        * schema
        *
-       * @param responses {array} - an array of responses
+       * @param responses {object} - a hash of responses
        * @returns boolean
       */
       $scope.hasAResponseWithSchema = function (responses) {
@@ -93,12 +93,25 @@ SwaggerEditor.directive('swaggerOperation', function (defaults) {
        * Returns true if the operation responses has at least one response with
        * "headers" field
        *
-       * @param responses {array} - an array of responses
+       * @param responses {object} - a hash of responses
        * @returns boolean
       */
       $scope.hasAResponseWithHeaders = function (responses) {
         return _.keys(responses).some(function (responseCode) {
           return responses[responseCode] && responses[responseCode].headers;
+        });
+      };
+
+      /*
+       * Returns true if the operation responses has at least one response with
+       * examples
+       *
+       * @param responses {object} - a hash of responses
+       * @returns boolean
+      */
+      $scope.hasAResponseWithExamples = function (responses) {
+        return _.keys(responses).some(function (responseCode) {
+          return responses[responseCode] && responses[responseCode].examples;
         });
       };
     }

--- a/app/styles/components/operation.less
+++ b/app/styles/components/operation.less
@@ -124,7 +124,7 @@ li.operation {
   }
 
 
-  table.params, table.respns, table.security {
+  table.params, table.respns, table.security, table.examples {
     width: 100%;
 
     >thead {

--- a/app/templates/operation.html
+++ b/app/templates/operation.html
@@ -94,6 +94,7 @@
               <th>Description</th>
               <th ng-if="hasAResponseWithHeaders(operation.responses)">Headers</th>
               <th ng-if="hasAResponseWithSchema(operation.responses)">Schema</th>
+              <th ng-if="hasAResponseWithExamples(operation.responses)">Examples</th>
             </tr>
           </thead>
 
@@ -143,6 +144,18 @@
               </td>
               <td ng-if="hasAResponseWithSchema(operation.responses)">
                 <schema-model ng-if="response.schema" schema="response.schema"></schema-model>
+              </td>
+              <td ng-if="hasAResponseWithExamples(operation.responses)">
+                <table class="examples">
+                  <tbody>
+                    <tr ng-repeat="(exampleMimeType, example) in response.examples">
+                      <td>{{exampleMimeType}}</td>
+                      <td>
+                        <json-formatter json="example" open="1"></json-formatter>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
               </td>
             </tr>
           </tbody>


### PR DESCRIPTION
Renders response examples. This also fixes an error in
documentations for `hasAResponseWithSchema` and
`hasAResponseWithHeaders`.

Fixes https://github.com/swagger-api/swagger-editor/issues/674
Fixes https://github.com/swagger-api/swagger-editor/issues/698
Fixes https://github.com/swagger-api/swagger-editor/issues/652