### PR TITLE
[fileloader] Import a yaml file

### DIFF
--- a/app/scripts/services/fileloader.js
+++ b/app/scripts/services/fileloader.js
@@ -56,6 +56,16 @@ SwaggerEditor.service('FileLoader', function FileLoader($http, defaults, YAML) {
         throw new TypeError('load function only accepts a string');
       }
 
+      try {
+        JSON.parse(string);
+      } catch (error) {
+
+        // Do not change to JSON if it is YAML, and
+        // just resolve it
+        resolve(string);
+        return;
+      }
+
       YAML.load(string, function (error, json) {
         if (error) { return reject(error); }
 


### PR DESCRIPTION
In load method do not convert to json and back to yaml if it
is already a yaml.

Fix https://github.com/swagger-api/swagger-editor/issues/697.