### PR TITLE
Response headers was never shown

### DIFF
--- a/app/templates/operation.html
+++ b/app/templates/operation.html
@@ -119,7 +119,7 @@
               </td>
               <td marked="response.description"></td>
               <td ng-if="hasAResponseWithHeaders(operation.responses)">
-                <table ng-if="response.headers.length > 0" class="respnse-headers">
+                <table ng-if="response.headers" class="respnse-headers">
                   <thead>
                     <tr>
                       <th>Name</th>


### PR DESCRIPTION
Found that response headers was never shown, because the ng-if was checking for "response.header.length > 0", which will never be true, as "response.header" is an object (map-like) and not and array.