### PR TITLE
Bugfix #782 Definition 'undefined' error in Preview

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -49,7 +49,7 @@
     }
   },
   "devDependencies": {
-    "sway-worker": "~1.10.0",
+    "sway-worker": "~1.8.0",
     "angular-mocks": "~1.4.2"
   }
 }


### PR DESCRIPTION
This is the bugfix of #782 (Definition `undefined` error in Preview)