### PR TITLE
Add "editorReadOnly" flag to config/defaults.json.

### DIFF
--- a/app/config/defaults.json
+++ b/app/config/defaults.json
@@ -15,6 +15,7 @@
   "editorOptions": {
     "theme": "ace/theme/atom_dark"
   },
+  "editorReadOnly": true,
   "exampleFiles": [
     "default.yaml",
     "heroku-pets.yaml",

--- a/app/config/defaults.json.guide.js
+++ b/app/config/defaults.json.guide.js
@@ -62,6 +62,11 @@ var defaults = {
   editorOptions: {},
 
   /*
+   * Force the Ace editor to operate in Read Only mode. Useful for presentation API documentation.
+  */
+  editorReadOnly: false,
+
+  /*
    * List of example files to show to user to pick from. The URL to fetch each
    * example is a combination of `examplesFolder` and file name
   */

--- a/app/scripts/controllers/editor.js
+++ b/app/scripts/controllers/editor.js
@@ -1,7 +1,10 @@
 'use strict';
 
 SwaggerEditor.controller('EditorCtrl', function EditorCtrl($scope, $rootScope,
-  Editor, Builder, Storage, ExternalHooks, Preferences) {
+  Editor, Builder, Storage, ExternalHooks, Preferences, defaults) {
+
+  // Allow specifying readOnly editor in defaults.json
+  $scope.editorReadOnly = defaults && !!defaults.editorReadOnly;
 
   var debouncedOnAceChange = getDebouncedOnAceChange();
 

--- a/app/views/editor/editor.html
+++ b/app/views/editor/editor.html
@@ -2,5 +2,6 @@
   useWrapMode : true,
   mode: 'yaml',
   onLoad: aceLoaded,
-  onChange: aceChanged}">
+  onChange: aceChanged}"
+  ng-readonly="editorReadOnly">
 </div>


### PR DESCRIPTION
 Useful for displaying documentation to API consumers.

    Copyright permission is herby granted.