### PR TITLE
Added polyfill for Promise to support < IE11

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 'use strict';
 
+// Polyfills
+require('es6-promise').polyfill();
+
 // App CSS files
 require('font-awesome-webpack');
 require('./styles/main.less');

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "brace": "^0.8.0",
     "chai": "^3.5.0",
     "css-loader": "^0.23.1",
+    "es6-promise": "^3.1.2",
     "eslint": "^2.4.0",
     "eslint-config-google": "^0.5.0",
     "eslint-friendly-formatter": "^2.0.3",


### PR DESCRIPTION
Partially fixes issue: https://github.com/swagger-api/swagger-editor/issues/874

This fix is partial because although it fixes the Promise dependency, there is still an issue with IE 9. IE 9 does not support WebWorkers, which this app appears to depend on.

Fixes IE10 and IE 11