### PR TITLE
Use SWAGGER_PORT as the intial environment variable

### DIFF
--- a/server.js
+++ b/server.js
@@ -33,7 +33,7 @@ function startServer(port, cb) {
 
 // if this file was triggered directly, launch the server
 if (process.argv[1] === __filename) {
-  var PORT = process.env.PORT || 8080;
+  var PORT = process.env.SWAGGER_PORT || process.env.PORT || 8080;
 
   startServer(PORT, function(err) {
     if (err) {


### PR DESCRIPTION
Allow SWAGGER_PORT as env var to set the server port, keeping PORT and 8080 as fallbacks