### PR TITLE
Add another base case to a AST Manager recursive function

### DIFF
--- a/scripts/services/ast-manager.js
+++ b/scripts/services/ast-manager.js
@@ -55,6 +55,9 @@ SwaggerEditor.service('ASTManager', function ASTManager(YAML, $log) {
        * @return {Function} find(value)
       */
       function find(current) {
+        if (!current) {
+          return cb(invalidRange);
+        }
         if (current.tag === MAP_TAG) {
           for (i = 0; i < current.value.length; i++) {
             var pair = current.value[i];


### PR DESCRIPTION
Fixes #941
**Browsers I manually tested this feature in**
* [x] Google Chrome
* [ ] Firefox
* [ ] Microsoft Edge

