### PR TITLE
Update for Chrome 48+

### DIFF
--- a/docs/cors.md
+++ b/docs/cors.md
@@ -46,5 +46,5 @@ To run Chrome with HTTP access control disabled use  `--disable-web-security` fl
 For example in OSX you need to run the following command:
 
 ```
-/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --disable-web-security
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --disable-web-security --user-data-dir
 ```


### PR DESCRIPTION
The existing example will not work in 48 and newer versions of chrome. Disable-web-security also requires user-data-dir parameter in order to work in chrome 48+.

See [this bug](https://bugs.chromium.org/p/chromium/issues/detail?id=575690). It is safe to ignore the no value comment for user-data-dir, it has since been given a [default value](https://www.chromium.org/user-experience/user-data-directory).