### PR TITLE
Do not show description column when there is no description.

### DIFF
--- a/scripts/directives/operation.js
+++ b/scripts/directives/operation.js
@@ -114,6 +114,15 @@ SwaggerEditor.directive('swaggerOperation', function(defaults) {
           return responses[responseCode] && responses[responseCode].examples;
         });
       };
+
+      $scope.hasAParameterWithDescription = function(parameters) {
+        if (!Array.isArray(parameters)) {
+          return false;
+        }
+        return parameters.some(function(param) {
+          return param.description;
+        });
+      };
     }
   };
 });

--- a/templates/operation.html
+++ b/templates/operation.html
@@ -49,7 +49,7 @@
             <tr>
               <th>Name</th>
               <th>Located in</th>
-              <th>Description</th>
+              <th ng-if="hasAParameterWithDescription(getParameters())">Description</th>
               <th>Required</th>
               <th>Schema</th>
             </tr>
@@ -72,7 +72,7 @@
                 </a>
               </td>
               <td>{{parameter.in}}</td>
-              <td marked="parameter.description"></td>
+              <td ng-if="hasAParameterWithDescription(getParameters())" marked="parameter.description"></td>
               <td>{{parameter.required ? 'Yes' : 'No'}}</td>
               <td>
                 <schema-model schema="parameter.schema"></schema-model>


### PR DESCRIPTION
**Browsers I manually tested this feature in**
* [x] Google Chrome

fixes #974