### PR TITLE
fixed content-type from x-www-form-urlencoded to application/x-www-fo…

### DIFF
--- a/scripts/controllers/tryoperation.js
+++ b/scripts/controllers/tryoperation.js
@@ -134,7 +134,7 @@ SwaggerEditor.controller('TryOperation', function($scope, formdataFilter,
     if (hasRequestBody()) {
       var defaultConsumes = [
         'multipart/form-data',
-        'x-www-form-urlencoded',
+        'application/x-www-form-urlencoded',
         'application/json'
       ];
       schema.properties.contentType = {


### PR DESCRIPTION
**UI changes screenshots**
![image](https://cloud.githubusercontent.com/assets/3584916/16648133/2682fc5a-4465-11e6-9850-4246a570c9c9.png)


**Browsers I manually tested this feature in**
* [x] Google Chrome
* [x] Firefox
* [x] Microsoft Edge

…rm-urlencoded on 'send request' in 'try this operation'