### PR TITLE
Fix overflow error message inside modal on Firefox

### DIFF
--- a/styles/components/modal.less
+++ b/styles/components/modal.less
@@ -48,6 +48,11 @@
     a {
       color: @modal-link;
     }
+
+    .error.json-formatter-dark.json-formatter-row span {
+      white-space: initial;
+    }
+
   }
 
   .modal-footer {


### PR DESCRIPTION
**UI changes screenshots**

Before:

<img width="819" alt="screen shot 2016-07-07 at 21 51 53" src="https://cloud.githubusercontent.com/assets/2803147/16665864/ce9f14aa-448d-11e6-8a16-dceda2e62205.png">

After:

<img width="599" alt="screen shot 2016-07-07 at 21 51 30" src="https://cloud.githubusercontent.com/assets/2803147/16665865/cea1470c-448d-11e6-846b-0ef8f80cf084.png">


**Browsers I manually tested this feature in**
* [X] Google Chrome
* [X] Firefox
* [X] Safari

Signed-off-by: Thanasis Katsadas <thanasis00@gmail.com>
Signed-off-by: Dionysis Grigoropoulos <dgrig@erethon.com>