### PR TITLE
Added externalDocs rendering for operations

### DIFF
--- a/templates/operation.html
+++ b/templates/operation.html
@@ -41,6 +41,11 @@
       <div marked="operation.description"></div>
     </section>
 
+    <section class="external-docs" ng-if="operation.externalDocs">
+      <h4>External Documentation</h4>
+      <a href="{{operation.externalDocs.url}}" marked="operation.externalDocs.description"></a>
+    </section>
+
     <section class="parameters" ng-if="getParameters().length">
       <h4>Parameters</h4>
       <div>


### PR DESCRIPTION
I have added rendering for the externalDocs property for operations in the same way as it is rendered for the specs-info area.

**UI changes screenshots**
![swagger-externaldocs-operations](https://cloud.githubusercontent.com/assets/20414647/17657877/1947dbac-62c7-11e6-8934-d920d13319e0.PNG)

**Browsers I manually tested this feature in**
* [x] Google Chrome
* [x] Firefox
* [ ] Microsoft Edge