### PR TITLE
Introduced preference to disable sync between editor and preview for folding paths and operations. Improves performance for large YAMLs.

### DIFF
--- a/scripts/controllers/preferences.js
+++ b/scripts/controllers/preferences.js
@@ -5,6 +5,7 @@ SwaggerEditor.controller('PreferencesCtrl', function PreferencesCtrl($scope,
   $scope.keyPressDebounceTime = Preferences.get('keyPressDebounceTime');
   $scope.liveRender = Preferences.get('liveRender');
   $scope.autoComplete = Preferences.get('autoComplete');
+  $scope.editorFolding = Preferences.get('editorFolding');
   $scope.pointerResolutionBasePath =
     Preferences.get('pointerResolutionBasePath');
 
@@ -18,6 +19,7 @@ SwaggerEditor.controller('PreferencesCtrl', function PreferencesCtrl($scope,
 
     Preferences.set('liveRender', $scope.liveRender);
     Preferences.set('autoComplete', $scope.autoComplete);
+    Preferences.set('editorFolding', $scope.editorFolding);
     Preferences.set('pointerResolutionBasePath',
       $scope.pointerResolutionBasePath);
 

--- a/scripts/controllers/preview.js
+++ b/scripts/controllers/preview.js
@@ -243,11 +243,13 @@ SwaggerEditor.controller('PreviewCtrl', function PreviewCtrl(Storage, Builder,
       _.each(path, function(operation, operationName) {
         if (_.isObject(operation)) {
           operation.$folded = true;
-          FoldStateManager.foldEditor([
-            'paths',
-            pathName,
-            operationName
-          ], true);
+          if (Preferences.get('editorFolding')) {
+            FoldStateManager.foldEditor([
+              'paths',
+              pathName,
+              operationName
+            ], true);
+          }
         }
       });
     });
@@ -261,7 +263,9 @@ SwaggerEditor.controller('PreviewCtrl', function PreviewCtrl(Storage, Builder,
     _.each($scope.specs.definitions, function(definition, definitionName) {
       if (_.isObject(definition)) {
         definition.$folded = true;
-        FoldStateManager.foldEditor(['definitions', definitionName], true);
+        if (Preferences.get('editorFolding')) {
+          FoldStateManager.foldEditor(['definitions', definitionName], true);
+        }
       }
     });
   }

--- a/scripts/services/preferences.js
+++ b/scripts/services/preferences.js
@@ -28,6 +28,11 @@ SwaggerEditor.service('Preferences', function Preferences($localStorage,
     autoComplete: true,
 
     /*
+     * Disable/enable editor folding tight to preview folding for operations, paths, definitions
+    */
+    editorFolding: true,
+
+    /*
      * Wait time for editor to react to keyboard events
     */
     keyPressDebounceTime: defaults.keyPressDebounceTime,

--- a/templates/operation.html
+++ b/templates/operation.html
@@ -4,7 +4,7 @@
 
   <header ng-click="
       operation.$folded = !operation.$folded;
-      foldEditor(['paths', pathName, operationName], operation.$folded)
+      Preferences.get('editorFolding') ? foldEditor(['paths', pathName, operationName], operation.$folded) : null;
     ">
     <a
       class="focus-editor"

--- a/templates/path.html
+++ b/templates/path.html
@@ -1,6 +1,6 @@
 <header ng-click="
     path.$folded = !path.$folded;
-    foldEditor(['paths', pathName], path.$folded)">
+    Preferences.get('editorFolding') ? foldEditor(['paths', pathName], path.$folded) : null;">
 
   <h2>
     <a>{{pathName}}</a>

--- a/templates/preferences.html
+++ b/templates/preferences.html
@@ -45,6 +45,17 @@
         </tr>
         <tr>
           <th>
+            <label for="editorFolding">
+              <h5>Editor Folding</h4>
+              <p>Disable editor folding sync to preview folding of paths, operations and definitions for very large specs to keep preview experience smooth.</p>
+            </label>
+          </th>
+          <th>
+            <input type="checkbox" id="editorFolding" ng-model="editorFolding">
+          </th>
+        </tr>         
+        <tr>
+          <th>
             <label for="pointerResolutionBasePath">
               <h5>Pointer Resolution Base Path</h5>
               <p>

--- a/views/preview/preview.html
+++ b/views/preview/preview.html
@@ -22,7 +22,7 @@
     <h3 class="section-header">
       <a ng-click="
           specs.paths.$folded = !specs.paths.$folded;
-          foldEditor(['paths'], specs.paths.$folded);">
+          Preferences.get('editorFolding') ? foldEditor(['paths'], specs.paths.$folded) : null;">
 
           <span>Paths</span>
       </a>
@@ -47,7 +47,7 @@
     <h3 class="section-header">
       <a ng-click="
         specs.definitions.$folded = !specs.definitions.$folded;
-        foldEditor(['definitions'], specs.definitions.$folded);
+        Preferences.get('editorFolding') ? foldEditor(['definitions'], specs.definitions.$folded) : null;
       ">Models</a>
       <span class="on-hover">
         <a ng-click="listAllDefnitions()">List all models</a>
@@ -70,7 +70,7 @@
           <a
             ng-click="
               model.$folded = !model.$folded;
-              foldEditor(['definitions', modelName], model.$folded)
+              Preferences.get('editorFolding') ? foldEditor(['definitions', modelName], model.$folded) : null;
             "
             class="definition-title">
             {{modelName}}


### PR DESCRIPTION
This PR introduces a new preference that can be used to disable the sync between the editor and preview in terms of fold/unfold the spec when the user clicks on the path/operation/definition to show/hide them in the preview. (Default: Editor Folding is enabled as the current editor is)

This makes good performance improvement from user experience side when working with large spec files (I have on about 3000 Loc at the moment). 

If the user decides not to have the linked folding, it is not a big disadvantage. I often use the "list all operations" to have a quick view, and hit the "jump to yaml" arrow to quickly get into the corresponding part of the spec. 

**UI changes screenshots**

![image](https://cloud.githubusercontent.com/assets/20414647/17658070/fabf4ccc-62c8-11e6-8369-4ac387aa8089.png)

**Browsers I manually tested this feature in**
- [x] Google Chrome
- [x] Firefox
- [ ] Microsoft Edge
