### PR TITLE
Add the possibility to easily proxy API requests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ ADD     ./    /editor
 # The default port of the application
 EXPOSE  8080
 
-CMD ["http-server", "--cors", "-p8080", "/editor"]
+ENTRYPOINT ["http-server", "-p8080", "--cors", "/editor"]

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Valid Swagger JSON descriptions can then be generated and used with the full Swa
 
 The swagger-editor is published in a [public repository on Dockerhub](https://hub.docker.com/r/swaggerapi/swagger-editor/)
 
-You can run editor easily with docker:
+You can run editor easily with docker (and optionally proxy requests to your API endpoint):
 
 ```bash
 docker pull swaggerapi/swagger-editor
-docker run -p 80:8080 swaggerapi/swagger-editor
+docker run -p 80:8080 swaggerapi/swagger-editor [-P http://api-endpoint]
 ```
 
 #### Running Locally

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can run editor easily with docker (and optionally proxy requests to your API
 
 ```bash
 docker pull swaggerapi/swagger-editor
-docker run -p 80:8080 swaggerapi/swagger-editor [-P http://api-endpoint]
+docker run --rm -p 80:8080 swaggerapi/swagger-editor [-P http://api-endpoint]
 ```
 
 #### Running Locally


### PR DESCRIPTION
Hi guys,

We recently had an issue where we couldn't use Swagger to trigger requests to one of our APIs due to the CORS policy. Luckily, http-server was able to accommodate our case by allowing us to pass the "-P" option, along with our endpoint - so that http-server proxies all of the non-editor requests to our API. We've a container image with the change, but I thought that it might be nice to make this a part of the standard distribution. Additionally, I've changed the run command to only create ephemeral containers (in order not to pile those up).

Here's how it would work:
docker run --rm -p 80:8080 swaggerapi/swagger-editor [-P http://api-endpoint]

The change is pretty simple - converting CMD to ENTRYPOINT allows one to have sane defaults, with the additional flexibility of easily adding options in case they're needed.
