### PR TITLE
Make generator.swagger.io links protocol agnostic

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,9 +1,9 @@
 {
   "codegen": {
-    "servers": "http://generator.swagger.io/api/gen/servers",
-    "clients": "http://generator.swagger.io/api/gen/clients",
-    "server": "http://generator.swagger.io/api/gen/servers/{language}",
-    "client": "http://generator.swagger.io/api/gen/clients/{language}"
+    "servers": "//generator.swagger.io/api/gen/servers",
+    "clients": "//generator.swagger.io/api/gen/clients",
+    "server": "//generator.swagger.io/api/gen/servers/{language}",
+    "client": "//generator.swagger.io/api/gen/clients/{language}"
   },
   "analytics": {
     "google": {

--- a/config/defaults.json.guide.js
+++ b/config/defaults.json.guide.js
@@ -33,15 +33,15 @@ var defaults = {
      * Menu items are generated based on result of GET request to these
      * endpoint
     */
-    servers: 'http://generator.swagger.io/online/api/gen/servers',
-    clients: 'http://generator.swagger.io/online/api/gen/clients',
+    servers: '//generator.swagger.io/online/api/gen/servers',
+    clients: '//generator.swagger.io/online/api/gen/clients',
 
     /*
      * For each item in menu item, Swagger Editor will make calls to these
      * endpoint to download the generated code accordingly
     */
-    server: 'http://generator.swagger.io/online/api/gen/servers/{language}',
-    client: 'http://generator.swagger.io/online/api/gen/clients/{language}'
+    server: '//generator.swagger.io/online/api/gen/servers/{language}',
+    client: '//generator.swagger.io/online/api/gen/clients/{language}'
   },
 
   /*


### PR DESCRIPTION
Right now, when serving swagger-editor on a secure host, the communication to http://generater.swagger.io is blocked in all or most browsers due to it being flagged as insecure content. 

Making these links protocol agnostic makes sure that they will be using https:// whenever swagger-editor is also being accessed over https://