### PR TITLE
Make Swagger Editor Hosting in static Domain, browse with index.html

### DIFF
--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -7,8 +7,8 @@ var _ = require('lodash/string');
 $(function() {
   // Try bootstrapping the app with embedded defaults if it exists
   var embeddedDefaults = window.$$embeddedDefaults;
-  var pathname = window.location.pathname;
-
+  var pathname = window.location.pathname.replace("index.html", "");
+  
   if (!_.endsWith(pathname, '/')) {
     pathname += '/';
   }


### PR DESCRIPTION
Right now, if you host the swagger-editor on domain statically,
When you open localhost:8880/swagger-editor/index.html, you will get the following error from the bundle.js file:

```
bundle.js:169 Failed to load defaults.json from /swagger-editor/index.html/config/defaults.json(anonymous function)
```
