### PR TITLE
Fix the dev build, to use the dist-bundle as an entry point

### DIFF
--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -115,7 +115,6 @@ module.exports = function(options) {
 
     module: {
       loaders: loaders,
-      noParse: [/braintree-web\/dist\/braintree.js/]
     },
 
     resolveLoader: {

--- a/webpack-hot-dev-server.config.js
+++ b/webpack-hot-dev-server.config.js
@@ -1,21 +1,16 @@
-var path = require('path')
+var path = require("path")
 
-module.exports = require("./make-webpack-config")({
+module.exports = Object.assign(require("./webpack-dist-bundle.config.js"), {
   _special: {
-    loaders: {
-      'jsx': [ "react-hot-loader", "babel" ]
-    },
+    minimize: false,
+    sourcemaps: true,
     separateStylesheets: false,
   },
+
 	devtool: "eval",
-  output: {
-    pathinfo: true,
-    debug: true,
-    chunkFilename: "[id].js"
-  },
   devServer: {
     port: 3200,
-    publicPath: "/" ,
+    publicPath: "/dist" ,
     noInfo: true,
     colors: true,
     stats: {


### PR DESCRIPTION
@shockey 
This uses the `dist-bundle` as the base config, for hot-webpack.
This fixes the issue of `npm run dev` not working.