### PR TITLE
Add type: array validation for parameters

### DIFF
--- a/src/plugins/validation/semantic-validators/validators/items-required-for-array-objects.js
+++ b/src/plugins/validation/semantic-validators/validators/items-required-for-array-objects.js
@@ -43,6 +43,15 @@ export function validate({ resolvedSpec }) {
 
     }
 
+    if(path[path.length - 2] === "headers") {
+      if(obj.type === "array" && typeof obj.items !== "object") {
+        errors.push({
+          path,
+          message: "Headers with 'array' type require an 'items' property"
+        })
+      }
+    }
+
     if(Object.keys(obj).length) {
       return Object.keys(obj).map(k => walk(obj[k], [...path, k]))
 

--- a/src/plugins/validation/semantic-validators/validators/parameters.js
+++ b/src/plugins/validation/semantic-validators/validators/parameters.js
@@ -1,0 +1,35 @@
+// Assertation 1:
+// The items property for a parameter is required when its type is set to array
+
+export function validate({ resolvedSpec }) {
+  let errors = []
+  let warnings = []
+
+  function walk(obj, path) {
+    if(typeof obj !== "object" || obj === null) {
+      return
+    }
+
+    // 1
+    if(path[path.length - 2] === "parameters") {
+      if(obj.type === "array" && typeof obj.items !== "object") {
+        errors.push({
+          path,
+          message: "Parameters with 'array' type require an 'items' property."
+        })
+      }
+    }
+
+    if(Object.keys(obj).length) {
+      return Object.keys(obj).map(k => walk(obj[k], [...path, k]))
+
+    } else {
+      return null
+    }
+
+  }
+
+  walk(resolvedSpec, [])
+
+  return { errors, warnings }
+}

--- a/test/plugins/validation/semantic/items-required-for-array-objects.js
+++ b/test/plugins/validation/semantic/items-required-for-array-objects.js
@@ -1,0 +1,77 @@
+import expect from "expect"
+import { validate } from "plugins/validation/semantic-validators/validators/items-required-for-array-objects"
+
+describe("validation plugin - semantic - items required for array objects", () => {
+  it("should return an error when an array header object omits an `items` property", () => {
+    const spec = {
+      "swagger": "2.0",
+      "info": {
+        "version": "1.0.0",
+        "title": "Swagger Petstore"
+      },
+      "paths": {
+        "/pets": {
+          "get": {
+            "description": "Returns all pets from the system that the user has access to",
+            "responses": {
+              "200": {
+                "description": "pet response",
+                "headers": {
+                  "X-MyHeader": {
+                    "type": "array"
+                  }
+                }
+              },
+              "default": {
+                "description": "unexpected error"
+              }
+            }
+          }
+        }
+      }
+    }
+
+    let res = validate({ resolvedSpec: spec })
+    expect(res.errors.length).toEqual(1)
+    expect(res.errors[0].path).toEqual(["paths", "/pets", "get", "responses", "200", "headers", "X-MyHeader"])
+    expect(res.errors[0].message).toEqual("Headers with 'array' type require an 'items' property")
+    expect(res.warnings.length).toEqual(0)
+  })
+
+  it("should not return an error when an array header object has an `items` property", () => {
+    const spec = {
+      "swagger": "2.0",
+      "info": {
+        "version": "1.0.0",
+        "title": "Swagger Petstore"
+      },
+      "paths": {
+        "/pets": {
+          "get": {
+            "description": "Returns all pets from the system that the user has access to",
+            "responses": {
+              "200": {
+                "description": "pet response",
+                "headers": {
+                  "X-MyHeader": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "default": {
+                "description": "unexpected error"
+              }
+            }
+          }
+        }
+      }
+    }
+
+    let res = validate({ resolvedSpec: spec })
+    expect(res.errors.length).toEqual(0)
+    expect(res.warnings.length).toEqual(0)
+  })
+})

--- a/test/plugins/validation/semantic/parameters.js
+++ b/test/plugins/validation/semantic/parameters.js
@@ -1,0 +1,29 @@
+import expect from "expect"
+import { validate } from "plugins/validation/semantic-validators/validators/parameters"
+
+describe("validation plugin - semantic - parameters", () => {
+  it("should return an error when an array type parameter omits an `items` property", () => {
+    const spec = {
+      "paths": {
+        "/pets": {
+          "get": {
+            "parameters": [
+              {
+                "name": "tags",
+                "in": "query",
+                "description": "tags to filter by",
+                "type": "array"
+              }
+            ]
+          }
+        }
+      }
+    }
+
+    let res = validate({ resolvedSpec: spec })
+    expect(res.errors.length).toEqual(1)
+    expect(res.errors[0].path).toEqual(["paths", "/pets", "get", "parameters", "0"])
+    expect(res.errors[0].message).toEqual("Parameters with 'array' type require an 'items' property.")
+    expect(res.warnings.length).toEqual(0)
+  })
+})


### PR DESCRIPTION
Fixes #1239.

This only adds the validation for parameters, as it already exists for any object whose name is `schema` or parent's name is `definitions`.

@webron, asking you to review. I looked through the specification for any instances of `type: array` and it looks like we're covering it all, but want to be sure.