### PR TITLE
IE11 fixes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,6 +11,10 @@
       {
         "expose": "plugins",
         "src": "src/plugins"
+      },
+      {
+        "expose": "src",
+        "src": "src"
       }
     ]
   ]

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "boron": "^0.2.3",
+    "bowser": "1.6.1",
     "classnames": "^2.1.3",
     "core-js": "^2.4.1",
     "immutable": "^3.x.x",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "boron": "^0.2.3",
     "classnames": "^2.1.3",
+    "core-js": "^2.4.1",
     "immutable": "^3.x.x",
     "js-yaml": "^3.5.5",
     "json-beautify": "^1.0.1",

--- a/src/plugins/editor-autosuggest-keywords/keyword-map.js
+++ b/src/plugins/editor-autosuggest-keywords/keyword-map.js
@@ -2,7 +2,7 @@
 var Bool = ["true", "false"]
 var Anything = String
 
-var combine = (...objs) => Object.assign({}, ...objs)
+var combine = (...objs) => objs ? Object.assign({}, ...objs) : {}
 
 var makeValue = (val = "") => {
   return {

--- a/src/plugins/validation/validation.worker.js
+++ b/src/plugins/validation/validation.worker.js
@@ -1,3 +1,5 @@
+import "src/polyfills.js"
+
 import concat from "lodash/concat"
 import { validate } from "./structural-validation/validator"
 import { runSemanticValidators } from "./semantic-validators/hook"

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,0 +1,1 @@
+require("core-js/fn/object/values")

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,1 +1,5 @@
 require("core-js/fn/object/values")
+require("core-js/fn/object/assign")
+require("core-js/fn/object/assign")
+require("core-js/es6/string")
+require("core-js/es6/array")

--- a/webpack-dist-bundle.config.js
+++ b/webpack-dist-bundle.config.js
@@ -19,6 +19,7 @@ module.exports = require('./make-webpack-config.js')({
 
   entry: {
     "swagger-editor-bundle": [
+      "./src/polyfills.js",
       './src/index.js'
     ]
   },

--- a/webpack-dist.config.js
+++ b/webpack-dist.config.js
@@ -15,6 +15,7 @@ module.exports = require('./make-webpack-config.js')({
 
   entry: {
     "swagger-editor": [
+      "./src/polyfills.js",
       './src/index.js'
     ]
   },

--- a/webpack-hot-dev-server.config.js
+++ b/webpack-hot-dev-server.config.js
@@ -18,9 +18,11 @@ module.exports = require("./make-webpack-config.js")({
 
   entry: {
     "swagger-editor-bundle": [
+      "./src/polyfills.js",
       './src/index.js'
     ],
     'swagger-editor-standalone-preset': [
+      "./src/polyfills.js",
       './src/standalone/index.js'
     ],
     'commons': ['react']

--- a/webpack-standalone.config.js
+++ b/webpack-standalone.config.js
@@ -10,6 +10,7 @@ module.exports = require("./make-webpack-config.js")({
 
   entry: {
     "swagger-editor-standalone-preset": [
+      "./src/polyfills.js",
       "./src/standalone/index.js"
     ]
   },


### PR DESCRIPTION
Brings back our old friend.... IE11 compatibility 😄 

Changes:
- Adopted the `core-js` polyfill injection structure that UI uses already
- Pinned a secondary dependency `bowser` at version `1.6.1` to solve an issue with `react-split-pane`
- Modified `keyword-map.js` to fix an IE11 quirk with the rest operator

I don't feel _great_ about version pinning `bowser` since we don't use it in our codebase, but it fixes the IE11 with no fuss.

![image](https://user-images.githubusercontent.com/680248/27665969-7195602e-5c25-11e7-8dc7-e67669f32590.png)
