### PR TITLE
Fix startup error in Editor

### DIFF
--- a/src/plugins/validation/helpers.js
+++ b/src/plugins/validation/helpers.js
@@ -31,7 +31,9 @@ export function makeValidationWorker() {
       })
       if(validationErrors.length) {
         validationErrors.forEach(err => {
-          errActions.newSpecErr(err)
+          if(err) {
+            errActions.newSpecErr(err)
+          }
         })
       }
     }).catch(function (e) {


### PR DESCRIPTION
EZ.

Fixes this error:

```js
helpers.js:38 TypeError: Cannot read property 'set' of null
    at eval (swagger-ui.js:5290)
    at eval (swagger-ui.js:13214)
    at eval (combineReducers.js:37)
    at Array.forEach (<anonymous>)
    at eval (combineReducers.js:34)
    at Map.withMutations (immutable.js:1355)
    at eval (combineReducers.js:33)
    at computeNextEntry (<anonymous>:2:27469)
    at recomputeStates (<anonymous>:2:27769)
    at <anonymous>:2:31382
```