### PR TITLE
Removes path validation blocking the usage of partial path templating.

### DIFF
--- a/src/plugins/validation/semantic-validators/validators/paths.js
+++ b/src/plugins/validation/semantic-validators/validators/paths.js
@@ -13,9 +13,6 @@
 // Assertation 5:
 // Paths must have unique (name + in combination) parameters
 
-// Assertation 6:
-// Paths cannot have partial templates. (/path/abc{123} is illegal)
-
 // Assertation 7:
 // Paths cannot have literal query strings in them.
 
@@ -44,16 +41,6 @@ export function validate({ resolvedSpec }) {
     if(!path || !pathName) {
       return
     }
-
-    pathName.split("/").map(substr => {
-      // Assertation 6
-      if(templateRegex.test(substr) && substr.replace(templateRegex, "").length > 0) {
-        errors.push({
-          path: `paths.${pathName}`,
-          message: "Partial path templating is not allowed."
-        })
-      }
-    })
 
     if(pathName.indexOf("?") > -1) {
       errors.push({

--- a/test/plugins/validation/semantic/paths.js
+++ b/test/plugins/validation/semantic/paths.js
@@ -252,33 +252,6 @@ describe("validation plugin - semantic - paths", function(){
   })
 
   describe("Paths must have unique name + in parameters", () => {
-
-    it("should return one problem for an name + in collision", function(){
-      const spec = {
-        paths: {
-          "/CoolPath/{id}": {
-            parameters: [{
-              name: "id",
-              in: "path"
-            }]
-          },
-          "/CoolPath/{count}": {
-            parameters: [{
-              name: "count",
-              in: "path"
-            }]
-          }
-        }
-      }
-
-      let res = validate({ resolvedSpec: spec })
-      expect(res.errors).toEqual([{
-        message: "Equivalent paths are not allowed.",
-        path: "paths./CoolPath/{count}"
-      }])
-      expect(res.warnings).toEqual([])
-    })
-
     it("should return no problems for an name collision only", function(){
       const spec = {
         paths: {
@@ -407,34 +380,6 @@ describe("validation plugin - semantic - paths", function(){
   })
 
   describe("Integrations", () => {
-
-
-    it("should return two problems for an illegal query string in a path string", function(){
-      const spec = {
-        paths: {
-          "/report?rdate={relative_date}": {
-            parameters: [{
-              name: "relative_date",
-              in: "path"
-            }]
-          }
-        }
-      }
-
-      let res = validate({ resolvedSpec: spec })
-      expect(res.errors).toEqual([
-        {
-          message: "Partial path templating is not allowed.",
-          path: "paths./report?rdate={relative_date}"
-        },
-        {
-          message: "Query strings in paths are not allowed.",
-          path: "paths./report?rdate={relative_date}"
-        }
-      ])
-      expect(res.warnings).toEqual([])
-    })
-
     it.skip("should return two problems for an equivalent path string missing a parameter definition", function(){
       const spec = {
         paths: {

--- a/test/plugins/validation/semantic/paths.js
+++ b/test/plugins/validation/semantic/paths.js
@@ -300,47 +300,6 @@ describe("validation plugin - semantic - paths", function(){
 
   })
 
-  describe("Paths cannot have partial templates", () => {
-
-    it("should return one problem for an illegal partial path template", function(){
-      const spec = {
-        paths: {
-          "/CoolPath/user{id}": {
-            parameters: [{
-              name: "id",
-              in: "path"
-            }]
-          }
-        }
-      }
-
-      let res = validate({ resolvedSpec: spec })
-      expect(res.errors).toEqual([{
-        message: "Partial path templating is not allowed.",
-        path: "paths./CoolPath/user{id}"
-      }])
-      expect(res.warnings).toEqual([])
-    })
-
-    it("should return no problems for a correct path template", function(){
-      const spec = {
-        paths: {
-          "/CoolPath/{id}": {
-            parameters: [{
-              name: "id",
-              in: "path"
-            }]
-          }
-        }
-      }
-
-      let res = validate({ resolvedSpec: spec })
-      expect(res.errors).toEqual([])
-      expect(res.warnings).toEqual([])
-    })
-
-  })
-
   describe("Paths cannot have query strings in them", () => {
 
     it("should return one problem for an stray '?' in a path string", function(){


### PR DESCRIPTION
Fixes https://github.com/swagger-api/swagger-editor/issues/1303 (added by @shockey)

Adds support for partial templates (e.g. '\api\Reports({id})' as opposed to '\api\Reports\id' ).
required for url paths following the OData conventions