### PR TITLE
Update dist deploy script

### DIFF
--- a/swagger-editor-dist-package/deploy.sh
+++ b/swagger-editor-dist-package/deploy.sh
@@ -3,14 +3,22 @@
 # Parameter Expansion: http://stackoverflow.com/questions/6393551/what-is-the-meaning-of-0-in-a-bash-script
 cd "${0%/*}"
 
-# Get UI version
+# Get Editor version
 EDITOR_VERSION=$(node -p "require('../package.json').version")
 
-# Replace our version placeholder with UI's version
-sed -i "s|\$\$VERSION|$EDITOR_VERSION|g" package.json
+# Replace our version placeholder with Editor's version
+sed -i.bak "s/\$\$VERSION/$EDITOR_VERSION/g" package.json
+rm package.json.bak
 
 # Copy Editor's dist files to our directory
 cp ../dist/* .
+
+# Copy index.html
+cp ../index.html .
+
+# Rewire `./dist` references to `.` in index.html
+sed -i.bak "s/\.\/dist/\./g" index.html
+rm index.html.bak
 
 if [ "$PUBLISH_DIST" = "true" ] || [ "$TRAVIS" = "true" ] ; then
   npm publish .


### PR DESCRIPTION
This PR:
- adds `index.html` to `swagger-editor-dist`
- makes `deploy.sh` `sed` commands valid in both Linux and macOS/BSD `sed` flavors
- updates `deploy.sh` comments for clarity

CC: #1490 