### PR TITLE
Don't validate parameter `type` when there is no `in` value

### DIFF
--- a/src/plugins/validation/semantic-validators/validators/parameters.js
+++ b/src/plugins/validation/semantic-validators/validators/parameters.js
@@ -19,7 +19,6 @@ export function validate({ resolvedSpec }) {
         })
       }
       if(!obj.type && obj.in && obj.in !== "body") {
-        debugger
         errors.push({
           path,
           message: "Non-body parameters require a 'type' property."

--- a/src/plugins/validation/semantic-validators/validators/parameters.js
+++ b/src/plugins/validation/semantic-validators/validators/parameters.js
@@ -18,7 +18,8 @@ export function validate({ resolvedSpec }) {
           message: "Parameters with 'array' type require an 'items' property."
         })
       }
-      if(!obj.type && obj.in !== "body") {
+      if(!obj.type && obj.in && obj.in !== "body") {
+        debugger
         errors.push({
           path,
           message: "Non-body parameters require a 'type' property."


### PR DESCRIPTION
Fixes #1525.

This should cut down on cases of "mistaken identity" where `parameters` is used as a freely-named key (CC #1343).