### PR TITLE
Add try/catch to Ace autocompleters

### DIFF
--- a/src/plugins/editor-autosuggest/helpers.js
+++ b/src/plugins/editor-autosuggest/helpers.js
@@ -12,28 +12,34 @@ export function wrapCompleters(completers, cutoff = 100) {
     let ori = completer.getCompletions
     completer.getCompletions = function(editor, session, pos, prefix, callback) {
       let startTime = Date.now()
-      ori(editor, session, pos, prefix, (...args) => {
-        let msElapsed = Date.now() - startTime
-        lastSpeeds[i] = msElapsed
+      try {
+        ori(editor, session, pos, prefix, (...args) => {
+          let msElapsed = Date.now() - startTime
+          lastSpeeds[i] = msElapsed
 
-        if(isLiveCompletionDisabled && isPerformant()) {
-          console.warn("Manual autocomplete was performant - re-enabling live autocomplete")
-          editor.setOptions({
-            enableLiveAutocompletion: true
-          })
-          isLiveCompletionDisabled = false
-        }
+          if(isLiveCompletionDisabled && isPerformant()) {
+            console.warn("Manual autocomplete was performant - re-enabling live autocomplete")
+            editor.setOptions({
+              enableLiveAutocompletion: true
+            })
+            isLiveCompletionDisabled = false
+          }
 
-        if(msElapsed > cutoff && editor.getOption("enableLiveAutocompletion")) {
-          console.warn("Live autocomplete is slow - disabling it")
-          editor.setOptions({
-            enableLiveAutocompletion: false
-          })
-          isLiveCompletionDisabled = true
-        }
+          if(msElapsed > cutoff && editor.getOption("enableLiveAutocompletion")) {
+            console.warn("Live autocomplete is slow - disabling it")
+            editor.setOptions({
+              enableLiveAutocompletion: false
+            })
+            isLiveCompletionDisabled = true
+          }
 
-        callback(...args)
-      })
+          callback(...args)
+        })
+      } catch(e) {
+        console.error("Autocompleter encountered an error")
+        console.error(e)
+        callback(null, [])
+      }
     }
     return completer
   })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This PR uses the existing `wrapCompleters` interface to wrap our custom Ace completers in try/catch blocks.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

This PR fixes* #1414 (hopefully). This bug has been hard to pin down, but I've been able to consistently reproduce the OP's issue. 

My approach here hinges on the root cause I surmised about in #1414:

> I have a theory: when our autosuggest code throws an uncaught error, Ace returns the current character as the resolved autosuggest value - so when live autocomplete fires and ends with an error, that buffer is appended to the value under the cursor, and the user sees a repeated character.

This PR sidesteps that failure mode by catching errors from within our autosuggest plugins, and cleanly feeding an empty result into Ace's completion callback.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested the live autosuggest functionality a handful of times before and after the changes were applied, and the changes seem to consistently prevent the issue.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.