### PR TITLE
Don't apply security validation to properties objects

### DIFF
--- a/src/plugins/validation/semantic-validators/validators/security.js
+++ b/src/plugins/validation/semantic-validators/validators/security.js
@@ -1,7 +1,6 @@
 // Assertation 1:
 // Items in `security` must match a `securityDefinition`.
 
-
 export function validate({ resolvedSpec }) {
   let errors = []
   let warnings = []
@@ -12,17 +11,14 @@ export function validate({ resolvedSpec }) {
     if(typeof obj !== "object" || obj === null) {
       return
     }
-    
-    if(path.pop() === "properties") {
-      return null
-    }
 
     if(path[path.length - 2] === "security") {
 
       // Assertation 1
       Object.keys(obj).map(key => {
         let securityDefinition = securityDefinitions && securityDefinitions[key]
-        if (!securityDefinition) {
+
+        if (!securityDefinition && path.pop() == "0") {
           errors.push({
             message: "security requirements must match a security definition",
             path: path

--- a/src/plugins/validation/semantic-validators/validators/security.js
+++ b/src/plugins/validation/semantic-validators/validators/security.js
@@ -18,7 +18,7 @@ export function validate({ resolvedSpec }) {
       Object.keys(obj).map(key => {
         let securityDefinition = securityDefinitions && securityDefinitions[key]
 
-        if (!securityDefinition && path.pop() == "0") {
+        if (!securityDefinition && path[path.length -1] === "0") {
           errors.push({
             message: "security requirements must match a security definition",
             path: path

--- a/src/plugins/validation/semantic-validators/validators/security.js
+++ b/src/plugins/validation/semantic-validators/validators/security.js
@@ -12,6 +12,10 @@ export function validate({ resolvedSpec }) {
     if(typeof obj !== "object" || obj === null) {
       return
     }
+    
+    if(path.pop() === "properties") {
+      return
+    }
 
     if(path[path.length - 2] === "security") {
 

--- a/src/plugins/validation/semantic-validators/validators/security.js
+++ b/src/plugins/validation/semantic-validators/validators/security.js
@@ -18,7 +18,7 @@ export function validate({ resolvedSpec }) {
       Object.keys(obj).map(key => {
         let securityDefinition = securityDefinitions && securityDefinitions[key]
 
-        if (!securityDefinition && path[path.length -1] === "0") {
+        if (!securityDefinition && path[path.length -1] !== "properties") {
           errors.push({
             message: "security requirements must match a security definition",
             path: path

--- a/src/plugins/validation/semantic-validators/validators/security.js
+++ b/src/plugins/validation/semantic-validators/validators/security.js
@@ -14,7 +14,7 @@ export function validate({ resolvedSpec }) {
     }
     
     if(path.pop() === "properties") {
-      return
+      return null
     }
 
     if(path[path.length - 2] === "security") {


### PR DESCRIPTION
Don't apply security validation to properties objects

### Description
if the 'security' property is part of a 'properties' object, skip validation

### Motivation and Context
Fixes #1375 

### How Has This Been Tested?
running swagger-editor locally, no longer get validation error

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
