### PR TITLE
OpenAPI JSON/YAML download filenames

### DIFF
--- a/src/standalone/topbar/topbar.jsx
+++ b/src/standalone/topbar/topbar.jsx
@@ -206,11 +206,11 @@ export default class Topbar extends React.Component {
             </DropdownMenu>
             { showGenerateMenu ? <DropdownMenu className="long" {...makeMenuOptions("Generate Server")}>
               { this.state.servers
-                  .map(serv => <li><button type="button" onClick={this.downloadGeneratedFile.bind(null, "server", serv)}>{serv}</button></li>) }
+                  .map((serv, i) => <li key={i}><button type="button" onClick={this.downloadGeneratedFile.bind(null, "server", serv)}>{serv}</button></li>) }
             </DropdownMenu> : null }
             { showGenerateMenu ? <DropdownMenu className="long" {...makeMenuOptions("Generate Client")}>
               { this.state.clients
-                  .map(cli => <li><button type="button" onClick={this.downloadGeneratedFile.bind(null, "client", cli)}>{cli}</button></li>) }
+                  .map((cli, i) => <li key={i}><button type="button" onClick={this.downloadGeneratedFile.bind(null, "client", cli)}>{cli}</button></li>) }
             </DropdownMenu> : null }
           </div>
         </div>

--- a/src/standalone/topbar/topbar.jsx
+++ b/src/standalone/topbar/topbar.jsx
@@ -72,23 +72,30 @@ export default class Topbar extends React.Component {
   saveAsYaml = () => {
     // Editor content -> JS object -> YAML string
     let editorContent = this.props.specSelectors.specStr()
+    let isOAS3 = this.props.specSelectors.isOAS3()
+    let fileName = isOAS3 ? "openapi.yaml" : "swagger.yaml"
     let jsContent = YAML.safeLoad(editorContent)
     let yamlContent = YAML.safeDump(jsContent)
-    downloadFile(yamlContent, "swagger.yaml")
+    downloadFile(yamlContent, fileName)
   }
 
   saveAsJson = () => {
     // Editor content  -> JS object -> Pretty JSON string
     let editorContent = this.props.specSelectors.specStr()
+    let isOAS3 = this.props.specSelectors.isOAS3()
+    let fileName = isOAS3 ? "openapi.json" : "swagger.json"
     let jsContent = YAML.safeLoad(editorContent)
     let prettyJsonContent = beautifyJson(jsContent, null, 2)
-    downloadFile(prettyJsonContent, "swagger.json")
+    downloadFile(prettyJsonContent, fileName)
   }
 
   saveAsText = () => {
     // Download raw text content
+    console.warn("DEPRECATED: saveAsText will be removed in the next minor version.")
     let editorContent = this.props.specSelectors.specStr()
-    downloadFile(editorContent, "swagger.txt")
+    let isOAS3 = this.props.specSelectors.isOAS3()
+    let fileName = isOAS3 ? "openapi.txt" : "swagger.txt"
+    downloadFile(editorContent, fileName)
   }
 
   convertToYaml = () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This PR modifies JSON/YAML save functionality to name OpenAPI documents `openapi.[yaml|json]` instead of `swagger.[yaml|json]`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #1566.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested downloading an OpenAPI and Swagger document, and everything was correct.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.