### PR TITLE
Add semantic validator for $ref values

### DIFF
--- a/src/plugins/validation/semantic-validators/validators/walker.js
+++ b/src/plugins/validation/semantic-validators/validators/walker.js
@@ -76,6 +76,21 @@ export function validate({ jsSpec }) {
           message: `${path[path.length - 2]} $refs cannot match any of the following: ${humanFriendlyRefBlacklist}`
         })
       }
+
+
+
+      if(typeof value === "string") {
+        // eslint-disable-next-line no-unused-vars
+        const [refUrl, refPath] = value.split("#")
+
+        if(!refPath || refPath[0] !== "/") {
+          errors.push({
+            path,
+            message: "$refs must begin with `#/`"
+          })
+        }
+
+      }
     }
 
     if(typeof value !== "object") {

--- a/test/plugins/validation/semantic/walker.js
+++ b/test/plugins/validation/semantic/walker.js
@@ -387,5 +387,77 @@ describe("validation plugin - semantic - spec walker", () => {
 
     })
 
+    describe("Ref formatting", () => {
+
+      it("should return an error when a local $ref value does not begin with `#/`", () => {
+        const spec = {
+          paths: {
+            "/CoolPath/{id}": {
+              schema: {
+                $ref: "#definition/abc"
+              }
+            }
+          }
+        }
+
+        let res = validate({ jsSpec: spec })
+        expect(res.errors.length).toEqual(1)
+        expect(res.warnings.length).toEqual(0)
+        expect(res.errors[0].path).toEqual(["paths", "/CoolPath/{id}", "schema", "$ref"])
+        expect(res.errors[0].message).toContain("$refs must begin with")
+      })
+
+      it("should return an error when a remote $ref value does not begin with `#/`", () => {
+        const spec = {
+          paths: {
+            "/CoolPath/{id}": {
+              schema: {
+                $ref: "http://google.com/#definition/abc"
+              }
+            }
+          }
+        }
+
+        let res = validate({ jsSpec: spec })
+        expect(res.errors.length).toEqual(1)
+        expect(res.warnings.length).toEqual(0)
+        expect(res.errors[0].path).toEqual(["paths", "/CoolPath/{id}", "schema", "$ref"])
+        expect(res.errors[0].message).toContain("$refs must begin with")
+      })
+
+      it("should not return an error when a local $ref value begins with `#/`", () => {
+        const spec = {
+          paths: {
+            "/CoolPath/{id}": {
+              schema: {
+                $ref: "#/definition/abc"
+              }
+            }
+          }
+        }
+
+        let res = validate({ jsSpec: spec })
+        expect(res.errors.length).toEqual(0)
+        expect(res.warnings.length).toEqual(0)
+      })
+
+      it("should not return an error when a remote $ref value begins with `#/`", () => {
+        const spec = {
+          paths: {
+            "/CoolPath/{id}": {
+              schema: {
+                $ref: "http://google.com/#/definition/abc"
+              }
+            }
+          }
+        }
+
+        let res = validate({ jsSpec: spec })
+        expect(res.errors.length).toEqual(0)
+        expect(res.warnings.length).toEqual(0)
+      })
+
+    })
+
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Adds a semantic validator for Swagger 2.0 $ref values.

(OAS 3.0 support has been added to https://github.com/swagger-api/swagger-editor/issues/1460).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #1560.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- New unit tests
- Manual testing

### Screenshots (if appropriate):

<img width="1791" alt="messages image 3725460508" src="https://user-images.githubusercontent.com/680248/33049788-81552efa-ce16-11e7-8d67-80a2194e49f3.png">


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.