### PR TITLE
$ref formatting validation with whole-document paths

### DIFF
--- a/src/plugins/validation/get-timestamp.js
+++ b/src/plugins/validation/get-timestamp.js
@@ -1,7 +1,7 @@
 export default function getTimestamp() {
   if(typeof performance !== "undefined" && performance.now) {
     return performance.now()
-  } else if(typeof self.performance !== "undefined" && self.performance.now) {
+  } else if(typeof self !== "undefined" && typeof self.performance !== "undefined" && self.performance.now) {
     return self.performance.now()
   } else {
     return Date.now()

--- a/src/plugins/validation/semantic-validators/hook.js
+++ b/src/plugins/validation/semantic-validators/hook.js
@@ -5,28 +5,15 @@ import { transformPathToArray } from "../path-translator"
 
 import assign from "lodash/assign"
 import getTimestamp from "../get-timestamp"
-let request = require.context("./validators/", true, /\.js$/)
+import rawValidators from "./validators"
 let semanticValidators = []
 
 let LOG_SEMVAL_PERF = process.env.NODE_ENV !== "production"
 
-request.keys().forEach( function( key ){
-  if( key === "./hook.js" ) {
-    return
-  }
-
-  if( !key.match(/js$/) ) {
-    return
-  }
-
-  if( key.slice(2).indexOf("/") > -1) {
-    // skip files in subdirs
-    return
-  }
-
+Object.keys(rawValidators).forEach( function( key ) {
   semanticValidators.push({
     name: toTitleCase(key).replace(".js", "").replace("./", ""),
-    validate: request(key).validate
+    validate: rawValidators[key]
   })
 })
 

--- a/src/plugins/validation/semantic-validators/validators/index.js
+++ b/src/plugins/validation/semantic-validators/validators/index.js
@@ -1,15 +1,15 @@
-import { validate as dummy } from './dummy'
-import { validate as form_data } from './form-data'
-import { validate as items_required_for_array_objects } from './items-required-for-array-objects'
-import { validate as operation_ids } from './operation-ids'
-import { validate as operations } from './operations'
-import { validate as parameters } from './parameters'
-import { validate as paths } from './paths'
-import { validate as refs } from './refs'
-import { validate as schema } from './schema'
-import { validate as security_definitions } from './security-definitions'
-import { validate as security } from './security'
-import { validate as walker } from './walker'
+import { validate as dummy } from "./dummy"
+import { validate as form_data } from "./form-data"
+import { validate as items_required_for_array_objects } from "./items-required-for-array-objects"
+import { validate as operation_ids } from "./operation-ids"
+import { validate as operations } from "./operations"
+import { validate as parameters } from "./parameters"
+import { validate as paths } from "./paths"
+import { validate as refs } from "./refs"
+import { validate as schema } from "./schema"
+import { validate as security_definitions } from "./security-definitions"
+import { validate as security } from "./security"
+import { validate as walker } from "./walker"
 
 export default {
   dummy,

--- a/src/plugins/validation/semantic-validators/validators/index.js
+++ b/src/plugins/validation/semantic-validators/validators/index.js
@@ -1,0 +1,27 @@
+import { validate as dummy } from './dummy'
+import { validate as form_data } from './form-data'
+import { validate as items_required_for_array_objects } from './items-required-for-array-objects'
+import { validate as operation_ids } from './operation-ids'
+import { validate as operations } from './operations'
+import { validate as parameters } from './parameters'
+import { validate as paths } from './paths'
+import { validate as refs } from './refs'
+import { validate as schema } from './schema'
+import { validate as security_definitions } from './security-definitions'
+import { validate as security } from './security'
+import { validate as walker } from './walker'
+
+export default {
+  dummy,
+  form_data,
+  items_required_for_array_objects,
+  operation_ids,
+  operations,
+  parameters,
+  paths,
+  refs,
+  schema,
+  security_definitions,
+  security,
+  walker
+}

--- a/src/plugins/validation/semantic-validators/validators/refs.js
+++ b/src/plugins/validation/semantic-validators/validators/refs.js
@@ -20,7 +20,7 @@ function collectRefs(val, key, arr = []) {
   return arr
 }
 
-export function validate({ jsSpec , specStr }) {
+export function validate({ jsSpec }) {
   let errors = []
   let warnings = []
 

--- a/src/plugins/validation/semantic-validators/validators/refs.js
+++ b/src/plugins/validation/semantic-validators/validators/refs.js
@@ -6,23 +6,26 @@ import filter from "lodash/filter"
 import startsWith from "lodash/startsWith"
 import each from "lodash/each"
 
+function collectRefs(val, key, arr = []) {
+  if(key === "$ref") {
+    return arr.push(val)
+  }
+
+  if(typeof val !== "object") {
+    return
+  }
+
+  Object.keys(val).map(k => collectRefs(val[k], k, arr))
+
+  return arr
+}
+
 export function validate({ jsSpec , specStr }) {
   let errors = []
   let warnings = []
 
   // Assertation 1
-  // This is a "creative" way to approach the problem of collecting used $refs,
-  // but other solutions required walking the jsSpec recursively to detect $refs,
-  // which can be quite slow.
-  let refRegex = /\$ref.*["'](.*)["']/g
-  let match = refRegex.exec(specStr)
-  let refs = []
-  while(match !== null) {
-      refs.push(match[1])
-      match = refRegex.exec(specStr)
-  }
-
-  console.log(specStr)
+  const refs = collectRefs(jsSpec, "")
 
   // de-dupe the array, and filter out non-definition refs
   let definitionsRefs = filter(uniq(refs), v => startsWith(v, "#/definitions"))

--- a/src/plugins/validation/semantic-validators/validators/refs.js
+++ b/src/plugins/validation/semantic-validators/validators/refs.js
@@ -22,6 +22,8 @@ export function validate({ jsSpec , specStr }) {
       match = refRegex.exec(specStr)
   }
 
+  console.log(specStr)
+
   // de-dupe the array, and filter out non-definition refs
   let definitionsRefs = filter(uniq(refs), v => startsWith(v, "#/definitions"))
 

--- a/src/plugins/validation/semantic-validators/validators/walker.js
+++ b/src/plugins/validation/semantic-validators/validators/walker.js
@@ -83,10 +83,10 @@ export function validate({ jsSpec }) {
         // eslint-disable-next-line no-unused-vars
         const [refUrl, refPath] = value.split("#")
 
-        if(!refPath || refPath[0] !== "/") {
+        if(refPath && refPath[0] !== "/") {
           errors.push({
             path,
-            message: "$refs must begin with `#/`"
+            message: "$ref paths must begin with `#/`"
           })
         }
 

--- a/test/plugins/validation/data/petstore-expanded.swagger.js
+++ b/test/plugins/validation/data/petstore-expanded.swagger.js
@@ -556,3 +556,146 @@ export const PetstoreExpandedDereferenced = {
     }
   }
 }
+
+
+export const PetstoreExpandedYAML = `
+swagger: "2.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: foo@example.com
+    url: http://madskristensen.net
+  license:
+    name: MIT
+    url: http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT
+host: petstore.swagger.io
+basePath: /api
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /pets:
+    get:
+      description: |
+        Returns all pets from the system that the user has access to
+      operationId: findPets
+      parameters:
+        - name: tags
+          in: query
+          description: tags to filter by
+          required: false
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
+        - name: limit
+          in: query
+          description: maximum number of results to return
+          required: false
+          type: integer
+          format: int32
+      responses:
+        "200":
+          description: pet response
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Pet'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      description: Creates a new pet in the store.  Duplicates are allowed
+      operationId: addPet
+      parameters:
+        - name: pet
+          in: body
+          description: Pet to add to the store
+          required: true
+          schema:
+            $ref: '#/definitions/NewPet'
+      responses:
+        "200":
+          description: pet response
+          schema:
+            $ref: '#/definitions/Pet'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: find pet by id
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          type: integer
+          format: int64
+      responses:
+        "200":
+          description: pet response
+          schema:
+            $ref: '#/definitions/Pet'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      description: deletes a single pet based on the ID supplied
+      operationId: deletePet
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to delete
+          required: true
+          type: integer
+          format: int64
+      responses:
+        "204":
+          description: pet deleted
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+definitions:
+  Pet:
+    allOf:
+      - $ref: '#/definitions/NewPet'
+      - required:
+        - id
+        properties:
+          id:
+            type: integer
+            format: int64
+
+  NewPet:
+    required:
+      - name
+    properties:
+      name:
+        type: string
+      tag:
+        type: string
+
+  Error:
+    required:
+      - code
+      - message
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string
+`

--- a/test/plugins/validation/data/petstore-expanded.swagger.js
+++ b/test/plugins/validation/data/petstore-expanded.swagger.js
@@ -1,0 +1,558 @@
+export const PetstoreExpandedRaw = {
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team",
+      "email": "foo@example.com",
+      "url": "http://madskristensen.net"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/api",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "description": "Returns all pets from the system that the user has access to\n",
+        "operationId": "findPets",
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "tags to filter by",
+            "required": false,
+            "type": "array",
+            "collectionFormat": "csv",
+            "items": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "maximum number of results to return",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a new pet in the store.  Duplicates are allowed",
+        "operationId": "addPet",
+        "parameters": [
+          {
+            "name": "pet",
+            "in": "body",
+            "description": "Pet to add to the store",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NewPet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/pets/{id}": {
+      "get": {
+        "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+        "operationId": "find pet by id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to fetch",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "deletes a single pet based on the ID supplied",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to delete",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "pet deleted"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/NewPet"
+        },
+        {
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        }
+      ]
+    },
+    "NewPet": {
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "Error": {
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}
+
+export const PetstoreExpandedDereferenced = {
+  "swagger":"2.0",
+  "info":{
+    "version":"1.0.0",
+    "title":"Swagger Petstore",
+    "description":"A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+    "termsOfService":"http://swagger.io/terms/",
+    "contact":{
+      "name":"Swagger API Team",
+      "email":"foo@example.com",
+      "url":"http://madskristensen.net"
+    },
+    "license":{
+      "name":"MIT",
+      "url":"http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT"
+    }
+  },
+  "host":"petstore.swagger.io",
+  "basePath":"/api",
+  "schemes":[
+    "http"
+  ],
+  "consumes":[
+    "application/json"
+  ],
+  "produces":[
+    "application/json"
+  ],
+  "paths":{
+    "/pets":{
+      "get":{
+        "description":"Returns all pets from the system that the user has access to\n",
+        "operationId":"findPets",
+        "parameters":[
+          {
+            "name":"tags",
+            "in":"query",
+            "description":"tags to filter by",
+            "required":false,
+            "type":"array",
+            "collectionFormat":"csv",
+            "items":{
+              "type":"string"
+            }
+          },
+          {
+            "name":"limit",
+            "in":"query",
+            "description":"maximum number of results to return",
+            "required":false,
+            "type":"integer",
+            "format":"int32"
+          }
+        ],
+        "responses":{
+          "200":{
+            "description":"pet response",
+            "schema":{
+              "type":"array",
+              "items":{
+                "allOf":[
+                  {
+                    "required":[
+                      "name"
+                    ],
+                    "properties":{
+                      "name":{
+                        "type":"string"
+                      },
+                      "tag":{
+                        "type":"string"
+                      }
+                    }
+                  },
+                  {
+                    "required":[
+                      "id"
+                    ],
+                    "properties":{
+                      "id":{
+                        "type":"integer",
+                        "format":"int64"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "default":{
+            "description":"unexpected error",
+            "schema":{
+              "required":[
+                "code",
+                "message"
+              ],
+              "properties":{
+                "code":{
+                  "type":"integer",
+                  "format":"int32"
+                },
+                "message":{
+                  "type":"string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post":{
+        "description":"Creates a new pet in the store.  Duplicates are allowed",
+        "operationId":"addPet",
+        "parameters":[
+          {
+            "name":"pet",
+            "in":"body",
+            "description":"Pet to add to the store",
+            "required":true,
+            "schema":{
+              "required":[
+                "name"
+              ],
+              "properties":{
+                "name":{
+                  "type":"string"
+                },
+                "tag":{
+                  "type":"string"
+                }
+              }
+            }
+          }
+        ],
+        "responses":{
+          "200":{
+            "description":"pet response",
+            "schema":{
+              "allOf":[
+                {
+                  "required":[
+                    "name"
+                  ],
+                  "properties":{
+                    "name":{
+                      "type":"string"
+                    },
+                    "tag":{
+                      "type":"string"
+                    }
+                  }
+                },
+                {
+                  "required":[
+                    "id"
+                  ],
+                  "properties":{
+                    "id":{
+                      "type":"integer",
+                      "format":"int64"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "default":{
+            "description":"unexpected error",
+            "schema":{
+              "required":[
+                "code",
+                "message"
+              ],
+              "properties":{
+                "code":{
+                  "type":"integer",
+                  "format":"int32"
+                },
+                "message":{
+                  "type":"string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{id}":{
+      "get":{
+        "description":"Returns a user based on a single ID, if the user does not have access to the pet",
+        "operationId":"find pet by id",
+        "parameters":[
+          {
+            "name":"id",
+            "in":"path",
+            "description":"ID of pet to fetch",
+            "required":true,
+            "type":"integer",
+            "format":"int64"
+          }
+        ],
+        "responses":{
+          "200":{
+            "description":"pet response",
+            "schema":{
+              "allOf":[
+                {
+                  "required":[
+                    "name"
+                  ],
+                  "properties":{
+                    "name":{
+                      "type":"string"
+                    },
+                    "tag":{
+                      "type":"string"
+                    }
+                  }
+                },
+                {
+                  "required":[
+                    "id"
+                  ],
+                  "properties":{
+                    "id":{
+                      "type":"integer",
+                      "format":"int64"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "default":{
+            "description":"unexpected error",
+            "schema":{
+              "required":[
+                "code",
+                "message"
+              ],
+              "properties":{
+                "code":{
+                  "type":"integer",
+                  "format":"int32"
+                },
+                "message":{
+                  "type":"string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete":{
+        "description":"deletes a single pet based on the ID supplied",
+        "operationId":"deletePet",
+        "parameters":[
+          {
+            "name":"id",
+            "in":"path",
+            "description":"ID of pet to delete",
+            "required":true,
+            "type":"integer",
+            "format":"int64"
+          }
+        ],
+        "responses":{
+          "204":{
+            "description":"pet deleted"
+          },
+          "default":{
+            "description":"unexpected error",
+            "schema":{
+              "required":[
+                "code",
+                "message"
+              ],
+              "properties":{
+                "code":{
+                  "type":"integer",
+                  "format":"int32"
+                },
+                "message":{
+                  "type":"string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions":{
+    "Pet":{
+      "allOf":[
+        {
+          "required":[
+            "name"
+          ],
+          "properties":{
+            "name":{
+              "type":"string"
+            },
+            "tag":{
+              "type":"string"
+            }
+          }
+        },
+        {
+          "required":[
+            "id"
+          ],
+          "properties":{
+            "id":{
+              "type":"integer",
+              "format":"int64"
+            }
+          }
+        }
+      ]
+    },
+    "NewPet":{
+      "required":[
+        "name"
+      ],
+      "properties":{
+        "name":{
+          "type":"string"
+        },
+        "tag":{
+          "type":"string"
+        }
+      }
+    },
+    "Error":{
+      "required":[
+        "code",
+        "message"
+      ],
+      "properties":{
+        "code":{
+          "type":"integer",
+          "format":"int32"
+        },
+        "message":{
+          "type":"string"
+        }
+      }
+    }
+  }
+}

--- a/test/plugins/validation/semantic/index.js
+++ b/test/plugins/validation/semantic/index.js
@@ -1,0 +1,22 @@
+import expect from "expect"
+import { runSemanticValidators } from "src/plugins/validation/semantic-validators/hook.js"
+
+import {
+  PetstoreExpandedRaw,
+  PetstoreExpandedDereferenced
+} from "../data/petstore-expanded.swagger.js"
+
+describe("semantic validation integration tests", () => {
+  describe("Swagger2 Petstore Expanded", () => {
+    it.only("should not return any problems about the petstore definition", () => {
+      const res = runSemanticValidators({
+        jsSpec: PetstoreExpandedRaw,
+        resolvedSpec: PetstoreExpandedDereferenced,
+        specStr: JSON.stringify(PetstoreExpandedRaw),
+        getLineNumberForPath: () => null
+      })
+
+      expect(res).toEqual([])
+    })
+  })
+})

--- a/test/plugins/validation/semantic/index.js
+++ b/test/plugins/validation/semantic/index.js
@@ -3,16 +3,28 @@ import { runSemanticValidators } from "src/plugins/validation/semantic-validator
 
 import {
   PetstoreExpandedRaw,
-  PetstoreExpandedDereferenced
+  PetstoreExpandedDereferenced,
+  PetstoreExpandedYAML
 } from "../data/petstore-expanded.swagger.js"
 
 describe("semantic validation integration tests", () => {
-  describe("Swagger2 Petstore Expanded", () => {
-    it.only("should not return any problems about the petstore definition", () => {
+  describe.only("Swagger2 Petstore Expanded", () => {
+    it("should not return any problems about the petstore definition as JSON", () => {
       const res = runSemanticValidators({
         jsSpec: PetstoreExpandedRaw,
         resolvedSpec: PetstoreExpandedDereferenced,
         specStr: JSON.stringify(PetstoreExpandedRaw),
+        getLineNumberForPath: () => null
+      })
+
+      expect(res).toEqual([])
+    })
+
+    it("should not return any problems about the petstore definition as YAML", () => {
+      const res = runSemanticValidators({
+        jsSpec: PetstoreExpandedRaw,
+        resolvedSpec: PetstoreExpandedDereferenced,
+        specStr: PetstoreExpandedYAML,
         getLineNumberForPath: () => null
       })
 

--- a/test/plugins/validation/semantic/index.js
+++ b/test/plugins/validation/semantic/index.js
@@ -8,7 +8,7 @@ import {
 } from "../data/petstore-expanded.swagger.js"
 
 describe("semantic validation integration tests", () => {
-  describe.only("Swagger2 Petstore Expanded", () => {
+  describe("Swagger2 Petstore Expanded", () => {
     it("should not return any problems about the petstore definition as JSON", () => {
       const res = runSemanticValidators({
         jsSpec: PetstoreExpandedRaw,

--- a/test/plugins/validation/semantic/walker.js
+++ b/test/plugins/validation/semantic/walker.js
@@ -404,7 +404,7 @@ describe("validation plugin - semantic - spec walker", () => {
         expect(res.errors.length).toEqual(1)
         expect(res.warnings.length).toEqual(0)
         expect(res.errors[0].path).toEqual(["paths", "/CoolPath/{id}", "schema", "$ref"])
-        expect(res.errors[0].message).toContain("$refs must begin with")
+        expect(res.errors[0].message).toContain("$ref paths must begin with")
       })
 
       it("should return an error when a remote $ref value does not begin with `#/`", () => {
@@ -422,7 +422,7 @@ describe("validation plugin - semantic - spec walker", () => {
         expect(res.errors.length).toEqual(1)
         expect(res.warnings.length).toEqual(0)
         expect(res.errors[0].path).toEqual(["paths", "/CoolPath/{id}", "schema", "$ref"])
-        expect(res.errors[0].message).toContain("$refs must begin with")
+        expect(res.errors[0].message).toContain("$ref paths must begin with")
       })
 
       it("should not return an error when a local $ref value begins with `#/`", () => {
@@ -447,6 +447,38 @@ describe("validation plugin - semantic - spec walker", () => {
             "/CoolPath/{id}": {
               schema: {
                 $ref: "http://google.com/#/definition/abc"
+              }
+            }
+          }
+        }
+
+        let res = validate({ jsSpec: spec })
+        expect(res.errors.length).toEqual(0)
+        expect(res.warnings.length).toEqual(0)
+      })
+
+      it("should not return an error when a remote $ref value is a whole-document path", () => {
+        const spec = {
+          paths: {
+            "/CoolPath/{id}": {
+              schema: {
+                $ref: "http://google.com/#"
+              }
+            }
+          }
+        }
+
+        let res = validate({ jsSpec: spec })
+        expect(res.errors.length).toEqual(0)
+        expect(res.warnings.length).toEqual(0)
+      })
+
+      it("should not return an error when a remote $ref value is a whole-document path", () => {
+        const spec = {
+          paths: {
+            "/CoolPath/{id}": {
+              schema: {
+                $ref: "http://google.com/"
               }
             }
           }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

- Fixes a corner case where $refs that reference an entire remote document would fail validation
- Adds an integration test set that ensures Petstore Expanded doesn't report any errors or warnings
- Fixes a mostly-unrelated issue with the $ref collector not being able to tabulate reference usage in JSON definitions

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

https://github.com/swagger-api/swagger-editor/pull/1570#issuecomment-346046947.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- I added four unit tests.
- I tested my changes manually within the Editor

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.