### PR TITLE
Use prop-types dependency for React-16 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "immutable": "^3.x.x",
     "js-yaml": "^3.5.5",
     "json-beautify": "^1.0.1",
+    "prop-types": "15.6.0",
     "react": "^15.6.2",
     "react-addons-css-transition-group": "^15.4.2",
     "react-dd-menu": "^2.0.0",

--- a/src/layout.jsx
+++ b/src/layout.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react"
+import React from "react"
+import PropTypes from "prop-types"
 
 export default class EditorLayout extends React.Component {
 

--- a/src/plugins/editor/components/editor-container.jsx
+++ b/src/plugins/editor/components/editor-container.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react"
+import React from "react"
+import PropTypes from "prop-types"
 import debounce from "lodash/debounce"
 
 

--- a/src/plugins/editor/components/editor.jsx
+++ b/src/plugins/editor/components/editor.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react"
+import React from "react"
+import PropTypes from "prop-types"
 import AceEditor from "react-ace"
 import editorPluginsHook from "../editor-plugins/hook"
 import { placeMarkerDecorations } from "../editor-helpers/marker-placer"

--- a/src/plugins/jump-to-path/components.jsx
+++ b/src/plugins/jump-to-path/components.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react"
+import React from "react"
+import PropTypes from "prop-types"
 import JumpIcon from "./jump-icon.svg"
 
 export class JumpToPath extends React.Component {

--- a/src/standalone/standalone-layout.js
+++ b/src/standalone/standalone-layout.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react"
+import React from "react"
+import PropTypes from "prop-types"
 
 export default class StandaloneLayout extends React.Component {
 

--- a/src/standalone/topbar/topbar.jsx
+++ b/src/standalone/topbar/topbar.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react"
+import React from "react"
+import PropTypes from "prop-types"
 import Swagger from "swagger-client"
 import "whatwg-fetch"
 import DropdownMenu from "./DropdownMenu"


### PR DESCRIPTION
### Description

Add "prop-types" dependency to package.json. Update import statements throughout so that they explicitly get PropTypes from the prop-types package instead of the react package.

### Motivation and Context

PropTypes has been removed from React-16. People wishing to use React-16 will have a bad time. Importing PropTypes through an explicit dependency instead of through react will solve this problem.

### How Has This Been Tested?

Build using npm run build and integrated into my project.

### Types of changes
- [x] No code changes (changes to documentation, CI, metadata, etc)
- [x] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed... Didn't run any unit tests, are there any in the package?
