### PR TITLE
Add global switching logic to disable semantic validation for OAS3

### DIFF
--- a/src/plugins/validate/index.js
+++ b/src/plugins/validate/index.js
@@ -71,7 +71,16 @@ function makeTraverseOnce(getSystem) {
       results[name] = []
     }
 
-    const json = getSystem().specSelectors.jsonAsJS()
+    const system = getSystem()
+
+    const json = system.specSelectors.jsonAsJS()
+
+    const isSwagger2 = system.specSelectors.isSwagger2 || null
+    const isOAS3 = system.specSelectors.isOAS3 || null
+
+    if((isSwagger2 && !isSwagger2()) || (isOAS3 && isOAS3())) {
+      return
+    }
 
     getSystem().fn.traverse(json)
       .forEach(function() { // Remember: this cannot be a fat-arrow function, because we need to read "this"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Don't run Swagger 2 validation on OAS 3.0 🤔 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes swagger-api/swagger-editor#1600, fixes swagger-api/swagger-editor#1599.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Existing unit tests pass; manually tested as well.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.