### PR TITLE
Add semantic validator for "\Z" anchors in regex patterns

### DIFF
--- a/src/plugins/validate/validators/schema.js
+++ b/src/plugins/validate/validators/schema.js
@@ -91,3 +91,23 @@ export const validateReadOnlyPropertiesNotRequired = () => (system) => {
       }, [])
     })
 }
+
+// See https://github.com/swagger-api/swagger-editor/issues/1601
+export const validateSchemaPatternHasNoZAnchors = () => (system) => {
+  return system.validateSelectors
+    .allSchemas()
+    .then(nodes => {
+      return nodes.reduce((acc, node) => {
+        const schemaObj = node.node
+        const { pattern } = schemaObj || {}
+        if(typeof pattern === "string" && pattern.indexOf("\\Z") > -1) {
+          acc.push({
+            message: `"\\Z" anchors are not allowed in regular expression patterns`,
+            path: [...node.path, "pattern"],
+            level: "error",
+          })
+        }
+        return acc
+      }, [])
+    })
+}

--- a/test/plugins/validate/schema.js
+++ b/test/plugins/validate/schema.js
@@ -512,5 +512,82 @@ describe("validation plugin - semantic - schema", function() {
         return expectNoErrorsOrWarnings(spec)
       })
     })
+    describe("definitions", function() {
+      it("should return an error when a schema has a Z anchor in its pattern", () => {
+
+        // Given
+        const spec = {
+          paths: {
+            $ref: "#/definitions/asdf"
+          },
+          "definitions": {
+            "asdf": {
+              type: "string",
+              pattern: "^[-a-zA-Z0-9_]+\\Z"
+            }
+          }
+        }
+
+        // When
+        return validateHelper(spec)
+          .then(system => {
+
+            // Then
+            expect(system.errSelectors.allErrors().count()).toEqual(1)
+            const firstError = system.errSelectors.allErrors().first().toJS()
+            expect(firstError.message).toEqual(`"\\Z" anchors are not allowed in regular expression patterns`)
+            expect(firstError.path).toEqual(["definitions", "asdf", "pattern"])
+          })
+
+      })
+      it("should return an error when a subschema has a Z anchor in its pattern", () => {
+
+        // Given
+        const spec = {
+          paths: {
+            $ref: "#/definitions/asdf"
+          },
+          "definitions": {
+            "asdf": {
+              type: "object",
+              properties: {
+                slug: {
+                  type: "string",
+                  pattern: "^[-a-zA-Z0-9_]+\\Z"
+                }
+              }
+            }
+          }
+        }
+
+        // When
+        return validateHelper(spec)
+          .then(system => {
+
+            // Then
+            expect(system.errSelectors.allErrors().count()).toEqual(1)
+            const firstError = system.errSelectors.allErrors().first().toJS()
+            expect(firstError.message).toEqual(`"\\Z" anchors are not allowed in regular expression patterns`)
+            expect(firstError.path).toEqual(["definitions", "asdf", "properties", "slug", "pattern"])
+          })
+
+      })
+
+      it("should not return an error when a regex pattern doesn't use a Z anchor", () => {
+        const spec = {
+          paths: {
+            $ref: "#/definitions/asdf"
+          },
+          "definitions": {
+            "asdf": {
+              type: "string",
+              pattern: "^[-a-zA-Z0-9_]+"
+            }
+          }
+        }
+
+        return expectNoErrorsOrWarnings(spec)
+      })
+    })
   })
 })

--- a/test/plugins/validate/schema.js
+++ b/test/plugins/validate/schema.js
@@ -512,7 +512,7 @@ describe("validation plugin - semantic - schema", function() {
         return expectNoErrorsOrWarnings(spec)
       })
     })
-    describe("definitions", function() {
+    describe("'pattern' Z anchors", function() {
       it("should return an error when a schema has a Z anchor in its pattern", () => {
 
         // Given


### PR DESCRIPTION
Fixes #1601.

The new semantic error is still wedged between some nonsense schema errors, but that's a fight for another day.

![messages image 2235525608](https://user-images.githubusercontent.com/680248/34397885-67915480-eb3f-11e7-9198-e8a51ce79caf.png)
