### PR TITLE
fix(semval): restore warning-level validators and add missing tests

### DIFF
--- a/src/plugins/validate-semantic/validators/refs.js
+++ b/src/plugins/validate-semantic/validators/refs.js
@@ -17,7 +17,7 @@ export const validateRefHasNoSiblings = () => system => {
             acc.push({
               message: `Sibling values are not allowed alongside $refs`,
               path: [...node.path.slice(0, -1), k],
-              level: "error"
+              level: "warning"
             })
           }
         })

--- a/test/plugins/validate-semantic/refs.js
+++ b/test/plugins/validate-semantic/refs.js
@@ -26,6 +26,7 @@ describe("validation plugin - semantic - refs", function() {
             expect(allErrors.length).toEqual(1)
             const firstError = allErrors[0]
             expect(firstError.message).toMatch("Sibling values are not allowed alongside $refs")
+            expect(firstError.level).toEqual("warning")
             expect(firstError.path).toEqual(["paths", "/CoolPath", "schema", "description"])
           })
       })

--- a/test/plugins/validate-semantic/refs.js
+++ b/test/plugins/validate-semantic/refs.js
@@ -32,6 +32,33 @@ describe("validation plugin - semantic - refs", function() {
     })
 
   })
+
+  describe("Unused definitions", () => {
+
+    it("should return a warning when a definition is declared but not used", () => {
+      const spec = {
+        paths: {
+          "/CoolPath": {}
+        },
+        definitions: {
+          abc: {
+            type: "string"
+          }
+        }
+      }
+
+      return validateHelper(spec)
+      .then(system => {
+        const allErrors = system.errSelectors.allErrors().toJS()
+        expect(allErrors.length).toEqual(1)
+        const firstError = allErrors[0]
+        expect(firstError.message).toMatch("Definition was declared but never used in document")
+        expect(firstError.level).toEqual("warning")
+        expect(firstError.path).toEqual(["definitions", "abc"])
+      })
+    })
+
+  })
   describe.skip("Refs are restricted in specific areas of a spec", () => {
     describe("Response $refs", () => {
       it("should return a problem for a parameters $ref in a response position", function(){

--- a/test/plugins/validate-semantic/refs.js
+++ b/test/plugins/validate-semantic/refs.js
@@ -5,33 +5,33 @@ describe("validation plugin - semantic - refs", function() {
   this.timeout(10 * 1000)
   describe("Ref siblings", () => {
 
-      it("should return a warning when another property is a sibling of a $ref", () => {
-        const spec = {
-          paths: {
-            "/CoolPath": {
-              schema: {
-                $ref: "#/definitions/abc",
-                description: "My very cool schema"
-              }
+    it("should return a warning when another property is a sibling of a $ref", () => {
+      const spec = {
+        paths: {
+          "/CoolPath": {
+            schema: {
+              $ref: "#/definitions/abc",
+              description: "My very cool schema"
             }
-          },
-          definitions: {
-            abc: {}
           }
+        },
+        definitions: {
+          abc: {}
         }
+      }
 
-        return validateHelper(spec)
-          .then(system => {
-            const allErrors = system.errSelectors.allErrors().toJS()
-            expect(allErrors.length).toEqual(1)
-            const firstError = allErrors[0]
-            expect(firstError.message).toMatch("Sibling values are not allowed alongside $refs")
-            expect(firstError.level).toEqual("warning")
-            expect(firstError.path).toEqual(["paths", "/CoolPath", "schema", "description"])
-          })
+      return validateHelper(spec)
+      .then(system => {
+        const allErrors = system.errSelectors.allErrors().toJS()
+        expect(allErrors.length).toEqual(1)
+        const firstError = allErrors[0]
+        expect(firstError.message).toMatch("Sibling values are not allowed alongside $refs")
+        expect(firstError.level).toEqual("warning")
+        expect(firstError.path).toEqual(["paths", "/CoolPath", "schema", "description"])
       })
-
     })
+
+  })
   describe.skip("Refs are restricted in specific areas of a spec", () => {
     describe("Response $refs", () => {
       it("should return a problem for a parameters $ref in a response position", function(){
@@ -48,13 +48,13 @@ describe("validation plugin - semantic - refs", function() {
         }
 
         return validateHelper(spec)
-          .then(system => {
-            const allErrors = system.errSelectors.allErrors().toJS()
-            expect(allErrors.length).toEqual(1)
-            const firstError = allErrors[0]
-            expect(firstError.path).toEqual(["paths", "/CoolPath", "responses", "200", "$ref"])
-            // expect(firstError.message).toMatch("")
-          })
+        .then(system => {
+          const allErrors = system.errSelectors.allErrors().toJS()
+          expect(allErrors.length).toEqual(1)
+          const firstError = allErrors[0]
+          expect(firstError.path).toEqual(["paths", "/CoolPath", "responses", "200", "$ref"])
+          // expect(firstError.message).toMatch("")
+        })
       })
 
       // FIXME: This poses a problem for our newer validation PR, as it only iterates over the resolved spec.
@@ -72,13 +72,13 @@ describe("validation plugin - semantic - refs", function() {
         }
 
         return validateHelper(spec)
-          .then(system => {
-            const allErrors = system.errSelectors.allErrors().toJS()
-            const firstError = allErrors[0]
-            expect(allErrors.length).toEqual(1)
-            expect(firstError.path).toEqual(["paths", "/CoolPath", "responses", "200", "$ref"])
-            expect(firstError.message).toEqual(`Response references are not allowed within schemas`)
-          })
+        .then(system => {
+          const allErrors = system.errSelectors.allErrors().toJS()
+          const firstError = allErrors[0]
+          expect(allErrors.length).toEqual(1)
+          expect(firstError.path).toEqual(["paths", "/CoolPath", "responses", "200", "$ref"])
+          expect(firstError.message).toEqual(`Response references are not allowed within schemas`)
+        })
       })
 
       it("should not return a problem for a responses $ref in a response position", function(){
@@ -145,10 +145,10 @@ describe("validation plugin - semantic - refs", function() {
         }
 
         return validateHelper(spec)
-          .then(system => {
-            const allErrors = system.errSelectors.allErrors().toJS()
-            expect(allErrors.length).toEqual(0)
-          })
+        .then(system => {
+          const allErrors = system.errSelectors.allErrors().toJS()
+          expect(allErrors.length).toEqual(0)
+        })
       })
 
       it("should not return a problem for a schema property named 'properties'", function(){
@@ -174,11 +174,11 @@ describe("validation plugin - semantic - refs", function() {
         }
 
         return validateHelper(spec)
-          .then(system => {
-            let allErrors = system.errSelectors.allErrors().toJS()
-            allErrors = allErrors.filter(a => a.level != "warning")
-            expect(allErrors.length).toEqual(0)
-          })
+        .then(system => {
+          let allErrors = system.errSelectors.allErrors().toJS()
+          allErrors = allErrors.filter(a => a.level != "warning")
+          expect(allErrors.length).toEqual(0)
+        })
       })
     })
     describe("Parameter $refs", () => {
@@ -195,13 +195,13 @@ describe("validation plugin - semantic - refs", function() {
         }
 
         return validateHelper(spec)
-          .then(system => {
-            const allErrors = system.errSelectors.allErrors().toJS()
-            expect(allErrors.length).toEqual(1)
-            const firstError = allErrors[0]
-            expect(firstError.path).toEqual(["paths", "/CoolPath", "parameters", "0", "$ref"])
-            expect(firstError.message).toMatch("")
-          })
+        .then(system => {
+          const allErrors = system.errSelectors.allErrors().toJS()
+          expect(allErrors.length).toEqual(1)
+          const firstError = allErrors[0]
+          expect(firstError.path).toEqual(["paths", "/CoolPath", "parameters", "0", "$ref"])
+          expect(firstError.message).toMatch("")
+        })
       })
 
       it("should return a problem for a responses $ref in a parameter position", function(){
@@ -216,13 +216,13 @@ describe("validation plugin - semantic - refs", function() {
         }
 
         return validateHelper(spec)
-          .then(system => {
-            const allErrors = system.errSelectors.allErrors().toJS()
-            expect(allErrors.length).toEqual(1)
-            const firstError = allErrors[0]
-            expect(firstError.path).toEqual(["paths", "/CoolPath", "parameters", "0", "$ref"])
-            expect(firstError.message).toMatch("")
-          })
+        .then(system => {
+          const allErrors = system.errSelectors.allErrors().toJS()
+          expect(allErrors.length).toEqual(1)
+          const firstError = allErrors[0]
+          expect(firstError.path).toEqual(["paths", "/CoolPath", "parameters", "0", "$ref"])
+          expect(firstError.message).toMatch("")
+        })
       })
 
       it("should not return a problem for a parameter $ref in a parameter position", function(){
@@ -237,10 +237,10 @@ describe("validation plugin - semantic - refs", function() {
         }
 
         return validateHelper(spec)
-          .then(system => {
-            const allErrors = system.errSelectors.allErrors().toJS()
-            expect(allErrors.length).toEqual(0)
-          })
+        .then(system => {
+          const allErrors = system.errSelectors.allErrors().toJS()
+          expect(allErrors.length).toEqual(0)
+        })
       })
     })
   })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

- Modifies $ref sibling validator to report warnings instead of errors; adds tests to match change
- Adds test for unused definition $ref validator, which was previously lacking tests

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

https://github.com/swagger-api/swagger-editor/issues/1305, https://github.com/swagger-api/swagger-editor/pull/1306.
