### PR TITLE
improve: enable `showExtensions` option by default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,7 @@ const defaults = {
   components: {
     EditorLayout
   },
+  showExtensions: true
 }
 
 module.exports = function SwaggerEditor(options) {


### PR DESCRIPTION
cc: https://github.com/swagger-api/swagger-ui/issues/4105#issuecomment-357921922