### PR TITLE
Validate $ref formatting via Swagger-Client $$ref meta patches

### DIFF
--- a/src/plugins/validate-semantic/validators/refs.js
+++ b/src/plugins/validate-semantic/validators/refs.js
@@ -1,9 +1,8 @@
 import get from "lodash/get"
 
 export const validateRefHasNoSiblings = () => system => {
-  return Promise.all([
-    system.validateSelectors.all$refArtifacts(),
-  ]).then(([nodes]) => {
+  return system.validateSelectors.all$refArtifacts()
+  .then((nodes) => {
       const immSpecJson = system.specSelectors.specJson()
       const specJson = immSpecJson.toJS ? immSpecJson.toJS() : {}
 
@@ -28,16 +27,9 @@ export const validateRefHasNoSiblings = () => system => {
 
 // Add warnings for unused definitions
 export const validateUnusedDefinitions = () => (system) => {
-  return Promise.all([
-    system.validateSelectors.all$refs(),
-    system.validateSelectors.all$refArtifacts()
-  ]).then(([refs, refArtifacts]) => {
-    const references = (
-      (refs.length ? refs : null)
-      || (refArtifacts.length ? refArtifacts : null)
-      || []
-    ).map(node => node.node)
-
+  return system.validateSelectors.all$refArtifacts()
+  .then((nodes) => {
+    const references = nodes.map(node => node.node)
     const errors = []
 
     system.specSelectors.definitions()
@@ -57,18 +49,11 @@ export const validateUnusedDefinitions = () => (system) => {
 }
 
 export const validateRefPathFormatting = () => (system) => {
-  return Promise.all([
-    system.validateSelectors.all$refs(),
-    system.validateSelectors.all$refArtifacts()
-  ]).then(([refs, refArtifacts]) => {
-    const nodes = (
-      (refs.length ? refs : null)
-      || (refArtifacts.length ? refArtifacts : null)
-      || []
-    )
+  return system.validateSelectors.all$refArtifacts()
+  .then((refArtifacts) => {
 
     const errors = []
-    nodes.forEach((node) => {
+    refArtifacts.forEach((node) => {
       const value = node.node
       if(typeof value === "string") {
         // eslint-disable-next-line no-unused-vars

--- a/src/plugins/validate-semantic/validators/refs.js
+++ b/src/plugins/validate-semantic/validators/refs.js
@@ -55,3 +55,36 @@ export const validateUnusedDefinitions = () => (system) => {
     return errors
   })
 }
+
+export const validateRefPathFormatting = () => (system) => {
+  return Promise.all([
+    system.validateSelectors.all$refs(),
+    system.validateSelectors.all$refArtifacts()
+  ]).then(([refs, refArtifacts]) => {
+    const nodes = (
+      (refs.length ? refs : null)
+      || (refArtifacts.length ? refArtifacts : null)
+      || []
+    )
+
+    const errors = []
+    nodes.forEach((node) => {
+      const value = node.node
+      if(typeof value === "string") {
+        // eslint-disable-next-line no-unused-vars
+        const [refUrl, refPath] = value.split("#")
+
+        if(!refPath || refPath[0] !== "/") {
+          errors.push({
+            // $ref instead of $$ref
+            path: [...node.path.slice(0, -1), "$ref"],
+            message: "$ref paths must begin with `#/`",
+            level: "error"
+          })
+        }
+      }
+    })
+
+    return errors
+  })
+}

--- a/test/plugins/validate-semantic/refs.js
+++ b/test/plugins/validate-semantic/refs.js
@@ -85,6 +85,27 @@ describe("validation plugin - semantic - refs", function() {
       })
     })
 
+    it("should return no errors when a JSON pointer is a well-formed remote reference", () => {
+      const spec = {
+        paths: {
+          "/CoolPath": {
+            $ref: "http://google.com#/myObj/abc"
+          }
+        },
+        myObj: {
+          abc: {
+            type: "string"
+          }
+        }
+      }
+
+      return validateHelper(spec)
+      .then(system => {
+        const allErrors = system.errSelectors.allErrors().toJS()
+        expect(allErrors).toEqual([])
+      })
+    })
+
   })
   describe.skip("Refs are restricted in specific areas of a spec", () => {
     describe("Response $refs", () => {

--- a/test/plugins/validate-semantic/refs.js
+++ b/test/plugins/validate-semantic/refs.js
@@ -59,6 +59,33 @@ describe("validation plugin - semantic - refs", function() {
     })
 
   })
+  describe("Malformed $ref values", () => {
+    it("should return an error when a JSON pointer lacks a leading `#/`", () => {
+      const spec = {
+        paths: {
+          "/CoolPath": {
+            $ref: "#myObj/abc"
+          }
+        },
+        myObj: {
+          abc: {
+            type: "string"
+          }
+        }
+      }
+
+      return validateHelper(spec)
+      .then(system => {
+        const allErrors = system.errSelectors.allErrors().toJS()
+        expect(allErrors.length).toEqual(1)
+        const firstError = allErrors[0]
+        expect(firstError.message).toMatch("$ref paths must begin with `#/`")
+        expect(firstError.level).toEqual("error")
+        expect(firstError.path).toEqual(["paths", "/CoolPath", "$ref"])
+      })
+    })
+
+  })
   describe.skip("Refs are restricted in specific areas of a spec", () => {
     describe("Response $refs", () => {
       it("should return a problem for a parameters $ref in a response position", function(){


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This PR uses Swagger-Client's upcoming `$$ref` meta patch fixes to validate $refs within a resolved spec.

Depends on https://github.com/swagger-api/swagger-js/pull/1237 being released.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #1560, again.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Test and control unit tests were added.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
