### PR TITLE
Fixed sub-schema selection for additionalProperties

### DIFF
--- a/src/plugins/validate-semantic/selectors.js
+++ b/src/plugins/validate-semantic/selectors.js
@@ -14,9 +14,12 @@ export const isSubSchema = (state, node) => (sys) => {
   if(path.length < 3) {
     return false
   }
-
-  if(node.parent.key == "properties" || node.parent.key === "additionalProperties") {
+  if(node.parent.key == "properties") {
     if(node.parent.parent && node.parent.parent.node && node.parent.parent.node.type === "object") {
+      return !sys.validateSelectors.isVendorExt(node)
+    }
+  } else if(node.key === "additionalProperties") {
+    if(node.parent && node.parent.node && node.parent.node.type === "object") {
       return !sys.validateSelectors.isVendorExt(node)
     }
   } else if(node.key == "items") {

--- a/test/plugins/selectors.js
+++ b/test/plugins/selectors.js
@@ -1,0 +1,249 @@
+import expect from "expect"
+import SwaggerUi from "swagger-ui"
+import ValidateBasePlugin from "plugins/validate-base"
+import ValidateSemanticPlugin from "plugins/validate-semantic"
+import ASTPlugin from "plugins/ast"
+
+function getSystem(spec) {
+  return new Promise((resolve) => {
+    const system = SwaggerUi({
+      spec,
+      domNode: null,
+      presets: [],
+      initialState: {
+        layout: undefined
+      },
+      plugins: [
+        SwaggerUi.plugins.SpecIndex,
+        SwaggerUi.plugins.ErrIndex,
+        SwaggerUi.plugins.DownloadUrl,
+        SwaggerUi.plugins.SwaggerJsIndex,
+        ASTPlugin,
+        ValidateBasePlugin,
+        ValidateSemanticPlugin,
+      ]
+    })
+    resolve(system)
+  })
+}
+
+describe("plugin - selectors", function() {
+  this.timeout(10 * 1000)
+
+  it("allSchemas should pick up parameter schemas", () => {
+    const spec = {
+      paths: {
+        test: {
+          parameters: [{
+            name: "common"
+          }],
+          get: {
+            parameters: [{
+              name: "tags"
+            }]
+          }
+        }
+      }
+    }
+
+    return getSystem(spec)
+      .then(system => system.validateSelectors.allSchemas())
+      .then(nodes => {
+        expect(nodes.length).toEqual(3) // the "common" parameter gets propagated to "get" method
+        expect(nodes[0].path).toEqual(["paths","test","parameters","0"])
+        expect(nodes[1].path).toEqual(["paths","test","get","parameters","0"])
+        expect(nodes[2].path).toEqual(["paths","test","get","parameters","1"])
+        expect(nodes[2].node).toEqual({name: "common"})
+      })
+  })
+
+  it("allSchemas should pick up response schemas", () => {
+    const spec = {
+      paths: {
+        test: {
+          get: {
+            responses: {
+              "200": {
+                schema: {
+                  type: "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return getSystem(spec)
+      .then(system => system.validateSelectors.allSchemas())
+      .then(nodes => {
+        expect(nodes.length).toEqual(1)
+        expect(nodes[0].path.join(".")).toEqual("paths.test.get.responses.200.schema")
+      })
+  })
+
+  it("allSchemas should pick up definitions", () => {
+    const spec = {
+      definitions: {
+        fooModel: {
+          type: "object",
+          properties: {
+          }
+        }
+      }
+    }
+
+    return getSystem(spec)
+      .then(system => system.validateSelectors.allSchemas())
+      .then(nodes => {
+        expect(nodes.length).toEqual(1)
+        expect(nodes[0].key).toEqual("fooModel")
+      })
+  })
+
+  it("allSchemas should pick up headers", () => {
+    const spec = {
+      paths: {
+        test: {
+          get: {
+            responses: {
+              "200": {
+                headers: {
+                  foo: {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return getSystem(spec)
+      .then(system => system.validateSelectors.allSchemas())
+      .then(nodes => {
+        expect(nodes.length).toEqual(1)
+        expect(nodes[0].path.join(".")).toEqual("paths.test.get.responses.200.headers.foo")
+      })
+  })
+
+  it("allSchemas should pick up subschemas in properties", () => {
+    const spec = {
+      definitions: {
+        fooModel: {
+          type: "object",
+          properties: {
+            foo: {
+              type: "string"
+            }
+          }
+        }
+      }
+    }
+
+    return getSystem(spec)
+      .then(system => system.validateSelectors.allSchemas())
+      .then(nodes => {
+        expect(nodes.length).toEqual(2)
+        expect(nodes[0].key).toEqual("fooModel")
+        expect(nodes[1].key).toEqual("foo")
+      })
+  })
+
+  it("allSchemas should pick up subschemas in additionalProperties - simple", () => {
+    const spec = {
+      definitions: {
+        fooModel: {
+          type: "object",
+          additionalProperties: {
+            type: "string"
+          }
+        }
+      }
+    }
+
+    return getSystem(spec)
+      .then(system => system.validateSelectors.allSchemas())
+      .then(nodes => {
+        expect(nodes.length).toEqual(2)
+        expect(nodes[0].key).toEqual("fooModel")
+        expect(nodes[1].key).toEqual("additionalProperties")
+      })
+  })
+
+  it("allSchemas should pick up subschemas in additionalProperties - complex", () => {
+    const spec = {
+      definitions: {
+        fooModel: {
+          type: "object",
+          additionalProperties: {
+            type: "object",
+            properties: {
+              foo: {
+                type: "string"
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return getSystem(spec)
+      .then(system => system.validateSelectors.allSchemas())
+      .then(nodes => {
+        expect(nodes.length).toEqual(3)
+        expect(nodes[0].key).toEqual("fooModel")
+        expect(nodes[1].key).toEqual("additionalProperties")
+        expect(nodes[2].key).toEqual("foo")
+      })
+  })
+
+  it("allSchemas should pick up subschemas in array", () => {
+    const spec = {
+      definitions: {
+        fooModel: {
+          type: "array",
+          items: {
+            type: "string"
+          }
+        }
+      }
+    }
+
+    return getSystem(spec)
+      .then(system => system.validateSelectors.allSchemas())
+      .then(nodes => {
+        expect(nodes.length).toEqual(2)
+        expect(nodes[0].key).toEqual("fooModel")
+        expect(nodes[1].key).toEqual("items")
+      })
+  })
+
+  it("allSchemas should pick up subschemas in array of objects", () => {
+    const spec = {
+      definitions: {
+        fooModel: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              foo: {
+                type: "string"
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return getSystem(spec)
+      .then(system => system.validateSelectors.allSchemas())
+      .then(nodes => {
+        expect(nodes.length).toEqual(3)
+        expect(nodes[0].key).toEqual("fooModel")
+        expect(nodes[1].key).toEqual("items")
+        expect(nodes[2].key).toEqual("foo")
+      })
+  })
+})

--- a/test/plugins/validate-semantic/schema.js
+++ b/test/plugins/validate-semantic/schema.js
@@ -239,6 +239,37 @@ describe("validation plugin - semantic - schema", function() {
           expect(allErrors.length).toEqual(0)
         })
     })
+    it("should not return an error when \"type\" is a property name inside additionalProperties", () => {
+      const spec = {
+        "definitions": {
+          "ApiResponse": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "code": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+
+      return validateHelper(spec)
+        .then(system => {
+          let allErrors = system.errSelectors.allErrors().toJS()
+          allErrors = allErrors.filter(a => a.level != "warning") // ignore warnings
+          expect(allErrors.length).toEqual(0)
+        })
+    })
     it("should not return an error when \"type\" is a model name", () => {
       const spec = {
         "definitions": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
The current spec sub-schema selector returns the children nodes of `additionalProperties` instead of the `additionalProperties` node itself. This is incorrect and causes potential validation bugs

Added new unit tests for the `allSchemas` selector

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
Fixes #1662



### How Has This Been Tested?
Added a whole bunch of unit tests for selectors

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
