### PR TITLE
semantic validator for OAS3 request body $ref values

### DIFF
--- a/src/plugins/validate-semantic/index.js
+++ b/src/plugins/validate-semantic/index.js
@@ -13,6 +13,7 @@ import * as refsValidateActions from "./validators/refs"
 import * as parametersValidateActions from "./validators/parameters"
 import * as operationsValidateActions from "./validators/operations"
 import * as operationsOAS3ValidateActions from "./validators/oas3/operations"
+import * as refsOAS3ValidateActions from "./validators/oas3/refs"
 import * as refs2and3ValidateActions from "./validators/2and3/refs"
 import * as parameters2and3ValidateActions from "./validators/2and3/parameters"
 import * as paths2and3ValidateActions from "./validators/2and3/paths"
@@ -56,6 +57,7 @@ export default function SemanticValidatorsPlugin({getSystem}) {
           ...operationsValidateActions,
           ...refs2and3ValidateActions,
           ...operationsOAS3ValidateActions,
+          ...refsOAS3ValidateActions,
           ...parameters2and3ValidateActions,
           ...paths2and3ValidateActions
         }

--- a/src/plugins/validate-semantic/selectors.js
+++ b/src/plugins/validate-semantic/selectors.js
@@ -11,6 +11,9 @@ export const isRootResponse = (state, node) => node.path[0] === "responses" && n
 export const isRootHeader = (state, node) => node.path[0] === "headers" && node.path.length === 2
 export const isRef = (state, node) => node.key === "$ref" && typeof node.node === "string" // This selector can be fooled.
 export const isRefArtifact = (state, node) => node.key === "$$ref" && typeof node.node === "string"
+export const isOAS3RootRequestBody = (state, node) => node.path.length === 3 && node.path[1] === "requestBodies"
+export const isOAS3OperationRequestBody = (state, node) => node.path.length === 4 && node.path[3] === "requestBody"
+export const isOAS3OperationCallbackRequestBody = (state, node) => node.path.length === 8 && node.path[7] === "requestBody"
 
 export const isSubSchema = (state, node) => (sys) => {
   const path = node.path
@@ -42,6 +45,17 @@ export const isParameter = (state, node) => (sys) => {
       || ( node.path[0] === "paths"
            && node.path[3] === "parameters"
            && node.path.length === 5)
+  )
+}
+
+export const isOAS3RequestBody = (state, node) => (sys) => {
+  if(sys.validateSelectors.isVendorExt(node)) {
+    return false
+  }
+  return (
+    sys.validateSelectors.isOAS3RootRequestBody(node)
+      || sys.validateSelectors.isOAS3OperationRequestBody(node)
+      || sys.validateSelectors.isOAS3OperationCallbackRequestBody(node)
   )
 }
 
@@ -111,6 +125,17 @@ export const allParameters = () => (system) => {
     name: "allParameters",
     fn: (node) => {
       if(system.validateSelectors.isParameter(node)) {
+        return node
+      }
+    },
+  })
+}
+
+export const allOAS3RequestBodies = () => (system) => {
+  return system.fn.traverseOnce({
+    name: "allOAS3RequestBodies",
+    fn: (node) => {
+      if(system.validateSelectors.isOAS3RequestBody(node)) {
         return node
       }
     },

--- a/src/plugins/validate-semantic/validators/oas3/refs.js
+++ b/src/plugins/validate-semantic/validators/oas3/refs.js
@@ -1,0 +1,31 @@
+export const validateOAS3RefsForRequestBodiesReferenceRequestBodyPositions = () => sys => {
+  return sys.validateSelectors
+    .allOAS3RequestBodies()
+    .then(nodes => {
+      return nodes.reduce((acc, node) => {
+        const value = node.node
+        const ref = value.$ref
+
+        if(!ref) {
+          return acc
+        }
+
+        const [, refPath] = ref.split("#")
+        const pathArr = refPath.split("/") || []
+        const parentRefKey = pathArr.slice(-2)[0]
+        const targetRefKey = pathArr.slice(-1)[0]
+        if(
+          targetRefKey !== "requestBody"
+          && parentRefKey !== "requestBody"
+          && parentRefKey !== "requestBodies"
+        ) {
+          acc.push({
+            level: "error",
+            message: `requestBody $refs must point to a position where a requestBody can be legally placed`,
+            path: [...node.path, "$ref"]
+          })
+        }
+        return acc
+      }, [])
+    })
+}

--- a/test/plugins/validate-semantic/oas3/refs.js
+++ b/test/plugins/validate-semantic/oas3/refs.js
@@ -1,0 +1,209 @@
+import expect from "expect"
+
+import validateHelper, { expectNoErrorsOrWarnings } from "../validate-helper.js"
+
+describe.only("validation plugin - semantic - oas3 refs", () => {
+  describe("$refs for request bodies must reference a request body by position", () => {
+    it("should return an error when a requestBody incorrectly references a local component schema", () => {
+      const spec = {
+        openapi: "3.0.0",
+        paths: {
+          "/": {
+            post: {
+              operationId: "myId",
+              requestBody: {
+                $ref: "#/components/schemas/MySchema"
+              }
+            }
+          }
+        },
+        components: {
+          schemas: {
+            MySchema: {
+              type: "string"
+            }
+          }
+        }
+      }
+
+      return validateHelper(spec)
+        .then(system => {
+          const allErrors = system.errSelectors.allErrors().toJS()
+          const firstError = allErrors[0]
+          expect(allErrors.length).toEqual(1)
+          expect(firstError.message).toEqual(`requestBody $refs must point to a position where a requestBody can be legally placed`)
+          expect(firstError.path).toEqual(["paths", "/", "post", "requestBody", "$ref"])
+        })
+    })
+    it("should return an error when a requestBody incorrectly references a remote component schema", () => {
+      const spec = {
+        openapi: "3.0.0",
+        paths: {
+          "/": {
+            post: {
+              operationId: "myId",
+              requestBody: {
+                $ref: "http://google.com/#/components/schemas/MySchema"
+              }
+            }
+          }
+        }
+      }
+
+      return validateHelper(spec)
+        .then(system => {
+          const allErrors = system.errSelectors.allErrors().toJS()
+          const firstError = allErrors[0]
+          expect(allErrors.length).toEqual(1)
+          expect(firstError.message).toEqual(`requestBody $refs must point to a position where a requestBody can be legally placed`)
+          expect(firstError.path).toEqual(["paths", "/", "post", "requestBody", "$ref"])
+        })
+    })
+    it("should return an error when a requestBody in a callback incorrectly references a local component schema", () => {
+      const spec = {
+        openapi: "3.0.0",
+        info: null,
+        version: "1.0.0-oas3",
+        title: "example",
+        paths: {
+          "/api/callbacks": {
+            post: {
+              responses: {
+                "200": {
+                  description: "OK"
+                }
+              },
+              callbacks: {
+                callback: {
+                  "/callback": {
+                    post: {
+                      requestBody: {
+                        $ref: "#/components/schemas/callbackRequest"
+                      },
+                      responses: {
+                        "200": {
+                          description: "OK"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        components: {
+          schemas: {
+            callbackRequest: {
+              type: "object",
+              properties: {
+                property1: {
+                  type: "integer",
+                  example: 10000
+                }
+              }
+            }
+          }
+        }
+      }
+
+      return validateHelper(spec)
+        .then(system => {
+          const allErrors = system.errSelectors.allErrors().toJS()
+          const firstError = allErrors[0]
+          expect(allErrors.length).toEqual(1)
+          expect(firstError.message).toEqual(`requestBody $refs must point to a position where a requestBody can be legally placed`)
+          expect(firstError.path).toEqual(["paths", "/api/callbacks", "post", "callbacks",
+          "callback", "/callback", "post", "requestBody", "$ref"])
+        })
+    })
+    it("should return no errors when a requestBody correctly references a local component request body", () => {
+      const spec = {
+        openapi: "3.0.0",
+        paths: {
+          "/": {
+            post: {
+              operationId: "myId",
+              requestBody: {
+                $ref: "#/components/requestBodies/MyBody"
+              }
+            }
+          }
+        },
+        components: {
+          requestBodies: {
+            MyBody: {
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      return expectNoErrorsOrWarnings(spec)
+    })
+    it("should return no errors when a requestBody correctly references a local operation request body", () => {
+      const spec = {
+        openapi: "3.0.0",
+        paths: {
+          "/": {
+            post: {
+              operationId: "myId",
+              requestBody: {
+                $ref: "#/paths/~1/put/requestBody"
+              }
+            },
+            put: {
+              requestBody: {
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      return expectNoErrorsOrWarnings(spec)
+    })
+    it("should return no errors when a requestBody correctly references a remote component request body", () => {
+      const spec = {
+        openapi: "3.0.0",
+        paths: {
+          "/": {
+            post: {
+              operationId: "myId",
+              requestBody: {
+                $ref: "http://google.com/#/components/requestBodies/MyBody"
+              }
+            }
+          }
+        },
+        components: {
+          requestBodies: {
+            MyBody: {
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      return expectNoErrorsOrWarnings(spec)
+    })
+  })
+})

--- a/test/plugins/validate-semantic/oas3/refs.js
+++ b/test/plugins/validate-semantic/oas3/refs.js
@@ -2,7 +2,7 @@ import expect from "expect"
 
 import validateHelper, { expectNoErrorsOrWarnings } from "../validate-helper.js"
 
-describe.only("validation plugin - semantic - oas3 refs", () => {
+describe("validation plugin - semantic - oas3 refs", () => {
   describe("$refs for request bodies must reference a request body by position", () => {
     it("should return an error when a requestBody incorrectly references a local component schema", () => {
       const spec = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This PR adds a semantic validator that restricts the types of $ref values allowed in Request Body positions.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes https://github.com/swagger-api/swagger-ui/issues/4164.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Test and control unit tests were added that check component, cross-operation, and remote references.

### Screenshots (if appropriate):

<img width="1676" alt="messages image 2715866566" src="https://user-images.githubusercontent.com/680248/37233356-b1635130-23a7-11e8-835e-e3e02f26e2af.png">



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.