### PR TITLE
fix(semval): add $ref location existential validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "immutable": "^3.x.x",
     "js-yaml": "^3.5.5",
     "json-beautify": "^1.0.1",
+    "json-refs": "^3.0.4",
     "prop-types": "15.6.0",
     "react": "^15.6.2",
     "react-addons-css-transition-group": "^15.4.2",

--- a/src/plugins/validate-semantic/validators/2and3/refs.js
+++ b/src/plugins/validate-semantic/validators/2and3/refs.js
@@ -1,5 +1,6 @@
 import get from "lodash/get"
 import { escapeJsonPointerToken } from "../../../refs-util"
+import { pathFromPtr } from "json-refs"
 
 export const validate2And3RefHasNoSiblings = () => system => {
   return system.validateSelectors.all$refs()
@@ -69,6 +70,33 @@ export const validate2And3RefPathFormatting = () => (system) => {
             // $ref instead of $$ref
             path: [...node.path.slice(0, -1), "$ref"],
             message: "$ref paths must begin with `#/`",
+            level: "error"
+          })
+        }
+      }
+    })
+
+    return errors
+  })
+}
+
+export const validate2And3RefPointersExist = () => (system) => {
+  const json = system.specSelectors.specJson()
+  return system.validateSelectors.all$refs()
+  .then((refs) => {
+    const errors = []
+
+    refs.forEach((node) => {
+      const value = node.node
+      if(typeof value === "string" && value[0] === "#") {
+        // if path starts with "#", i.e. it is a local ref
+        const path = pathFromPtr(value)
+
+        if(json.getIn(path) === undefined) {
+          errors.push({
+            // $ref instead of $$ref
+            path: [...node.path.slice(0, -1), "$ref"],
+            message: "$refs must reference a valid location in the document",
             level: "error"
           })
         }

--- a/src/plugins/validate-semantic/validators/2and3/refs.js
+++ b/src/plugins/validate-semantic/validators/2and3/refs.js
@@ -64,7 +64,7 @@ export const validate2And3RefPathFormatting = () => (system) => {
         // eslint-disable-next-line no-unused-vars
         const [refUrl, refPath] = value.split("#")
 
-        if(!refPath || refPath[0] !== "/") {
+        if(refPath && refPath[0] !== "/") {
           errors.push({
             // $ref instead of $$ref
             path: [...node.path.slice(0, -1), "$ref"],

--- a/src/plugins/validate-semantic/validators/2and3/refs.js
+++ b/src/plugins/validate-semantic/validators/2and3/refs.js
@@ -67,7 +67,6 @@ export const validate2And3RefPathFormatting = () => (system) => {
 
         if(refPath && refPath[0] !== "/") {
           errors.push({
-            // $ref instead of $$ref
             path: [...node.path.slice(0, -1), "$ref"],
             message: "$ref paths must begin with `#/`",
             level: "error"
@@ -89,12 +88,11 @@ export const validate2And3RefPointersExist = () => (system) => {
     refs.forEach((node) => {
       const value = node.node
       if(typeof value === "string" && value[0] === "#") {
-        // if path starts with "#", i.e. it is a local ref
+        // if pointer starts with "#", it is a local ref
         const path = pathFromPtr(value)
 
         if(json.getIn(path) === undefined) {
           errors.push({
-            // $ref instead of $$ref
             path: [...node.path.slice(0, -1), "$ref"],
             message: "$refs must reference a valid location in the document",
             level: "error"

--- a/test/plugins/validate-semantic/2and3/refs.js
+++ b/test/plugins/validate-semantic/2and3/refs.js
@@ -440,5 +440,49 @@ describe("validation plugin - semantic - 2and3 refs", function() {
         expect(allSemanticErrors).toEqual([])
       })
     })
+    it("should return no errors when a JSON pointer is a remote reference in Swagger 2", () => {
+      const spec = {
+        swagger: "2.0",
+        paths: {
+          "/CoolPath": {
+            $ref: "http://google.com#/myObj/abc"
+          },
+        },
+        myObj: {
+          abc: {
+            type: "string"
+          }
+        }
+      }
+
+      return validateHelper(spec)
+      .then(system => {
+        const allSemanticErrors = system.errSelectors.allErrors().toJS()
+          .filter(err => err.source !== "resolver")
+        expect(allSemanticErrors).toEqual([])
+      })
+    })
+    it("should return no errors when a JSON pointer is a remote reference in OpenAPI 3", () => {
+      const spec = {
+        openapi: "3.0.0",
+        paths: {
+          "/CoolPath": {
+            $ref: "http://google.com#/myObj/abc"
+          },
+        },
+        myObj: {
+          abc: {
+            type: "string"
+          }
+        }
+      }
+
+      return validateHelper(spec)
+      .then(system => {
+        const allSemanticErrors = system.errSelectors.allErrors().toJS()
+          .filter(err => err.source !== "resolver")
+        expect(allSemanticErrors).toEqual([])
+      })
+    })
   })
 })

--- a/test/plugins/validate-semantic/2and3/refs.js
+++ b/test/plugins/validate-semantic/2and3/refs.js
@@ -342,4 +342,101 @@ describe("validation plugin - semantic - 2and3 refs", function() {
     })
 
   })
+  describe("Nonexistent $ref pointers", () => {
+    it("should return an error when a local JSON pointer does not exist in Swagger 2", () => {
+      const spec = {
+        swagger: "2.0",
+        paths: {
+          "/CoolPath": {
+            $ref: "#/myObj/DoesNotExist"
+          }
+        },
+        myObj: {
+          abc: {
+            type: "string"
+          }
+        }
+      }
+
+      return validateHelper(spec)
+      .then(system => {
+        const allErrors = system.errSelectors.allErrors().toJS()
+        expect(allErrors.length).toEqual(1)
+        const firstError = allErrors[0]
+        expect(firstError.message).toMatch("$refs must reference a valid location in the document")
+        expect(firstError.level).toEqual("error")
+        expect(firstError.path).toEqual(["paths", "/CoolPath", "$ref"])
+      })
+    })
+    it("should return an error when a local JSON pointer does not exist in OpenAPI 3", () => {
+      const spec = {
+        openapi: "3.0.0",
+        paths: {
+          "/CoolPath": {
+            $ref: "#/myObj/DoesNotExist"
+          }
+        },
+        myObj: {
+          abc: {
+            type: "string"
+          }
+        }
+      }
+
+      return validateHelper(spec)
+      .then(system => {
+        const allErrors = system.errSelectors.allErrors().toJS()
+        expect(allErrors.length).toEqual(1)
+        const firstError = allErrors[0]
+        expect(firstError.message).toMatch("$refs must reference a valid location in the document")
+        expect(firstError.level).toEqual("error")
+        expect(firstError.path).toEqual(["paths", "/CoolPath", "$ref"])
+      })
+    })
+    it("should return no errors when a JSON pointer exists in Swagger 2", () => {
+      const spec = {
+        swagger: "2.0",
+        paths: {
+          "/CoolPath": {
+            $ref: "#/myObj/abc"
+          },
+        },
+        myObj: {
+          abc: {
+            type: "string"
+          }
+        }
+      }
+
+      return validateHelper(spec)
+      .then(system => {
+        const allSemanticErrors = system.errSelectors.allErrors().toJS()
+          .filter(err => err.source !== "resolver")
+        expect(allSemanticErrors).toEqual([])
+      })
+    })
+    it("should return no errors when a JSON pointer exists in OpenAPI 3", () => {
+      const spec = {
+        openapi: "3.0.0",
+        paths: {
+          "/CoolPath": {
+            $ref: "#/myObj/abc"
+          },
+        },
+        myObj: {
+          abc: {
+            type: "string"
+          }
+        }
+      }
+
+      return validateHelper(spec)
+      .then(system => {
+        const allSemanticErrors = system.errSelectors.allErrors().toJS()
+          .filter(err => err.source !== "resolver")
+        expect(allSemanticErrors).toEqual([])
+      })
+    })
+
+  })
 })

--- a/test/plugins/validate-semantic/2and3/refs.js
+++ b/test/plugins/validate-semantic/2and3/refs.js
@@ -296,11 +296,14 @@ describe("validation plugin - semantic - 2and3 refs", function() {
         paths: {
           "/CoolPath": {
             $ref: "http://google.com#/myObj/abc"
-          }
+          },
         },
         myObj: {
           abc: {
-            type: "string"
+            type: "string",
+            properties: {
+              $ref: "http://google.com/MyRegularURLReference"
+            }
           }
         }
       }
@@ -318,11 +321,14 @@ describe("validation plugin - semantic - 2and3 refs", function() {
         paths: {
           "/CoolPath": {
             $ref: "http://google.com#/myObj/abc"
-          }
+          },
         },
         myObj: {
           abc: {
-            type: "string"
+            type: "string",
+            properties: {
+              $ref: "http://google.com/MyRegularURLReference"
+            }
           }
         }
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This PR adds a new semantic validator that ensures `$ref` values that are local pointers lead to a path that actually exists in the document.

This is needed since the new lazy resolution strategy led to the resolver not surfacing all pointer errors at all times.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #1700.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests have been added.

### Screenshots (if appropriate):

<img width="862" alt="messages image 1076215372" src="https://user-images.githubusercontent.com/680248/37736003-f033a158-2d0c-11e8-92f3-0d5cdbd01527.png">

Caveat: once the path has been lazily resolved, a redundant Resolver Error may appear. I've chosen to not do anything about this for the time being, as it opens a small can of worms with regards to error filtering.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.