### PR TITLE
never generate folded block scalars when converting URL-imported JSON to YAML

### DIFF
--- a/src/standalone/topbar/topbar.jsx
+++ b/src/standalone/topbar/topbar.jsx
@@ -101,7 +101,9 @@ export default class Topbar extends React.Component {
         .then(res => res.text())
         .then(text => {
           this.props.specActions.updateSpec(
-            YAML.safeDump(YAML.safeLoad(text))
+            YAML.safeDump(YAML.safeLoad(text), {
+              lineWidth: -1
+            })
           )
         })
     }


### PR DESCRIPTION
Fixes #1734, see the issue for more context 😄 