### PR TITLE
fix(docker-releases): trim leading `v` from image names

### DIFF
--- a/build-tools/deploy-docker-hub-tag.sh
+++ b/build-tools/deploy-docker-hub-tag.sh
@@ -2,7 +2,7 @@ if [ $DOCKER_HUB_USERNAME ]; then
   docker login --username=$DOCKER_HUB_USERNAME --password=$DOCKER_HUB_PASSWORD;
 
   if [ ! -z "$TRAVIS_TAG" ]; then
-    DOCKER_IMAGE_TAG=$TRAVIS_TAG;
+    DOCKER_IMAGE_TAG=${TRAVIS_TAG#?};
     docker build -t $DOCKER_IMAGE_NAME .;
     docker tag $DOCKER_IMAGE_NAME $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG;
     docker push $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG;


### PR DESCRIPTION
Coordinating change for https://github.com/swagger-api/swagger-ui/pull/4567.
