### PR TITLE
fix: properly validate $ref value escaping

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "json-beautify": "^1.0.1",
     "json-refs": "^3.0.4",
     "prop-types": "15.6.0",
+    "querystring-browser": "^1.0.4",
     "react": "^15.6.2",
     "react-ace": "^4.1.6",
     "react-addons-css-transition-group": "^15.4.2",

--- a/src/plugins/refs-util.js
+++ b/src/plugins/refs-util.js
@@ -1,3 +1,5 @@
+import qs from "querystring"
+
 /**
  * Unescapes a JSON pointer.
  * @api public
@@ -6,7 +8,7 @@ export function unescapeJsonPointerToken(token) {
   if (typeof token !== "string") {
     return token
   }
-  return token.replace(/~1/g, "/").replace(/~0/g, "~")
+  return qs.unescape(token.replace(/~1/g, "/").replace(/~0/g, "~"))
 }
 
 /**
@@ -14,5 +16,5 @@ export function unescapeJsonPointerToken(token) {
  * @api public
  */
 export function escapeJsonPointerToken(token) {
-  return token.replace(/~/g, "~0").replace(/\//g, "~1")
+  return qs.escape(token.replace(/~/g, "~0").replace(/\//g, "~1"))
 }

--- a/src/plugins/refs-util.js
+++ b/src/plugins/refs-util.js
@@ -1,4 +1,4 @@
-import qs from "querystring"
+import qs from "querystring-browser"
 
 /**
  * Unescapes a JSON pointer.

--- a/src/plugins/validate-semantic/validators/2and3/refs.js
+++ b/src/plugins/validate-semantic/validators/2and3/refs.js
@@ -1,6 +1,6 @@
 import get from "lodash/get"
 import { escapeJsonPointerToken } from "../../../refs-util"
-import qs from "querystring"
+import qs from "querystring-browser"
 import { pathFromPtr } from "json-refs"
 
 export const validate2And3RefHasNoSiblings = () => system => {

--- a/src/plugins/validate-semantic/validators/2and3/refs.js
+++ b/src/plugins/validate-semantic/validators/2and3/refs.js
@@ -1,5 +1,6 @@
 import get from "lodash/get"
-import { escapeJsonPointerToken, unescapeJsonPointerToken } from "../../../refs-util"
+import { escapeJsonPointerToken } from "../../../refs-util"
+import qs from "querystring"
 import { pathFromPtr } from "json-refs"
 
 export const validate2And3RefHasNoSiblings = () => system => {
@@ -89,7 +90,7 @@ export const validate2And3RefPointersExist = () => (system) => {
       const value = node.node
       if(typeof value === "string" && value[0] === "#") {
         // if pointer starts with "#", it is a local ref
-        const path = pathFromPtr(unescapeJsonPointerToken(value))
+        const path = pathFromPtr(qs.unescape(value))
 
         if(json.getIn(path) === undefined) {
           errors.push({

--- a/src/plugins/validate-semantic/validators/2and3/refs.js
+++ b/src/plugins/validate-semantic/validators/2and3/refs.js
@@ -1,5 +1,5 @@
 import get from "lodash/get"
-import { escapeJsonPointerToken } from "../../../refs-util"
+import { escapeJsonPointerToken, unescapeJsonPointerToken } from "../../../refs-util"
 import { pathFromPtr } from "json-refs"
 
 export const validate2And3RefHasNoSiblings = () => system => {
@@ -89,7 +89,7 @@ export const validate2And3RefPointersExist = () => (system) => {
       const value = node.node
       if(typeof value === "string" && value[0] === "#") {
         // if pointer starts with "#", it is a local ref
-        const path = pathFromPtr(value)
+        const path = pathFromPtr(unescapeJsonPointerToken(value))
 
         if(json.getIn(path) === undefined) {
           errors.push({

--- a/src/plugins/validate-semantic/validators/2and3/refs.js
+++ b/src/plugins/validate-semantic/validators/2and3/refs.js
@@ -127,7 +127,7 @@ export const validate2And3RefPointersAreProperlyEscaped = () => (system) => {
         if(hasReservedChars) {
           errors.push({
             path: [...node.path.slice(0, -1), "$ref"],
-            message: "$ref pointers must be RFC 3986-compliant percent-encoded values",
+            message: "$ref values must be RFC3986-compliant percent-encoded URIs",
             level: "error"
           })
         }

--- a/test/plugins/validate-semantic/2and3/refs.js
+++ b/test/plugins/validate-semantic/2and3/refs.js
@@ -340,6 +340,154 @@ describe("validation plugin - semantic - 2and3 refs", function() {
         expect(allSemanticErrors).toEqual([])
       })
     })
+    it("should return an error when a JSON pointer uses incorrect percent-encoding in Swagger 2", () => {
+      const spec = {
+        "swagger": "2.0",
+        "paths": {
+          "/foo": {
+            "get": {
+              "responses": {
+                "200": {
+                  "description": "Success",
+                  "schema": {
+                    "$ref": "#/definitions/foo bar"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "definitions": {
+          "foo bar": {
+            "type": "string"
+          }
+        }
+      }
+
+      return validateHelper(spec)
+      .then(system => {
+        const allSemanticErrors = system.errSelectors.allErrors().toJS()
+          .filter(err => err.source !== "resolver")
+          expect(allSemanticErrors[0]).toInclude({
+            level: "warning",
+            message: "Definition was declared but never used in document",
+            path: ["definitions", "foo bar"]
+          })
+          expect(allSemanticErrors.length).toEqual(2)
+          expect(allSemanticErrors[1]).toInclude({
+            level: "error",
+            message: "$ref pointers must be RFC 3986-compliant percent-encoded values",
+            path: ["paths", "/foo", "get", "responses", "200", "schema", "$ref"]
+          })
+       })
+    })
+    it("should return an error when a JSON pointer uses incorrect percent-encoding in OpenAPI 3", () => {
+      const spec = {
+        "openapi": "3.0.0",
+        "paths": {
+          "/foo": {
+            "get": {
+              "responses": {
+                "200": {
+                  "description": "Success",
+                  "schema": {
+                    "$ref": "#/components/schemas/foo bar"
+                  }
+                }
+              }
+            }
+          }
+        },
+        components: {
+          schemas: {
+            "foo bar": {
+              "type": "string"
+            }
+          }
+        }
+      }
+
+      return validateHelper(spec)
+      .then(system => {
+        const allSemanticErrors = system.errSelectors.allErrors().toJS()
+          .filter(err => err.source !== "resolver")
+          expect(allSemanticErrors[0]).toInclude({
+            level: "warning",
+            message: "Definition was declared but never used in document",
+            path: ["components", "schemas", "foo bar"]
+          })
+          expect(allSemanticErrors.length).toEqual(2)
+          expect(allSemanticErrors[1]).toInclude({
+            level: "error",
+            message: "$ref pointers must be RFC 3986-compliant percent-encoded values",
+            path: ["paths", "/foo", "get", "responses", "200", "schema", "$ref"]
+          })
+      })
+    })
+    it("should return no errors when a JSON pointer uses correct percent-encoding in Swagger 2", () => {
+      const spec = {
+        "swagger": "2.0",
+        "paths": {
+          "/foo": {
+            "get": {
+              "responses": {
+                "200": {
+                  "description": "Success",
+                  "schema": {
+                    "$ref": "#/definitions/foo%20bar"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "definitions": {
+          "foo bar": {
+            "type": "string"
+          }
+        }
+      }
+
+      return validateHelper(spec)
+      .then(system => {
+        const allSemanticErrors = system.errSelectors.allErrors().toJS()
+          .filter(err => err.source !== "resolver")
+        expect(allSemanticErrors).toEqual([])
+      })
+    })
+    it("should return no errors when a JSON pointer uses correct percent-encoding in OpenAPI 3", () => {
+      const spec = {
+        "openapi": "3.0.0",
+        "paths": {
+          "/foo": {
+            "get": {
+              "responses": {
+                "200": {
+                  "description": "Success",
+                  "schema": {
+                    "$ref": "#/components/schemas/foo%20bar"
+                  }
+                }
+              }
+            }
+          }
+        },
+        components: {
+          schemas: {
+            "foo bar": {
+              "type": "string"
+            }
+          }
+        }
+      }
+
+      return validateHelper(spec)
+      .then(system => {
+        const allSemanticErrors = system.errSelectors.allErrors().toJS()
+          .filter(err => err.source !== "resolver")
+        expect(allSemanticErrors).toEqual([])
+      })
+    })
 
   })
   describe("Nonexistent $ref pointers", () => {

--- a/test/plugins/validate-semantic/2and3/refs.js
+++ b/test/plugins/validate-semantic/2and3/refs.js
@@ -376,7 +376,7 @@ describe("validation plugin - semantic - 2and3 refs", function() {
           expect(allSemanticErrors.length).toEqual(2)
           expect(allSemanticErrors[1]).toInclude({
             level: "error",
-            message: "$ref pointers must be RFC 3986-compliant percent-encoded values",
+            message: "$ref values must be RFC3986-compliant percent-encoded URIs",
             path: ["paths", "/foo", "get", "responses", "200", "schema", "$ref"]
           })
        })
@@ -419,7 +419,7 @@ describe("validation plugin - semantic - 2and3 refs", function() {
           expect(allSemanticErrors.length).toEqual(2)
           expect(allSemanticErrors[1]).toInclude({
             level: "error",
-            message: "$ref pointers must be RFC 3986-compliant percent-encoded values",
+            message: "$ref values must be RFC3986-compliant percent-encoded URIs",
             path: ["paths", "/foo", "get", "responses", "200", "schema", "$ref"]
           })
       })


### PR DESCRIPTION
Fixes #871.

Depends on https://github.com/swagger-api/swagger-js/pull/1322.

1. Raise validation errors for unescaped values.
2. Silence validation errors for properly escaped values.