### PR TITLE
feature: `getEditorMetadata` helper

### DIFF
--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -1,0 +1,22 @@
+### `getEditorMetadata`
+
+`getEditorMetadata` is a method that allows you to get information about the Editor's state without reaching directly into the plugin system.
+
+Example:
+
+```js
+const editor = SwaggerEditor({ /* your configuration here */ })
+
+SwaggerEditor.getEditorMetadata()
+```
+
+Result:
+
+```js
+{
+  contentString: String,
+  contentObject: Object,
+  isValid: Boolean,
+  errors: Array,
+}
+```

--- a/src/plugins/editor-metadata/index.js
+++ b/src/plugins/editor-metadata/index.js
@@ -1,0 +1,15 @@
+export default function(system) {
+  return {
+    rootInjects: {
+      getEditorMetadata() {
+        const allErrors = system.errSelectors.allErrors()
+        return {
+          contentString: system.specSelectors.specStr(),
+          contentObject: system.specSelectors.specJson().toJS(),
+          isValid: allErrors.size === 0,
+          errors: allErrors.toJS()
+        }
+      }
+    }
+  }
+}

--- a/test/plugins/editor-metadata/index.js
+++ b/test/plugins/editor-metadata/index.js
@@ -1,0 +1,164 @@
+import expect from "expect"
+import throttle from "lodash/throttle"
+import SwaggerUi from "swagger-ui"
+import EditorMetadataPlugin from "plugins/editor-metadata"
+
+function getSystem(spec) {
+  return new Promise((resolve) => {
+    const system = SwaggerUi({
+      spec,
+      domNode: null,
+      presets: [
+        SwaggerUi.plugins.SpecIndex,
+        SwaggerUi.plugins.ErrIndex,
+        SwaggerUi.plugins.DownloadUrl,
+        SwaggerUi.plugins.SwaggerJsIndex,
+      ],
+      initialState: {
+        layout: undefined
+      },
+      plugins: [
+        EditorMetadataPlugin,
+        () => ({
+          statePlugins: {
+            configs: {
+              actions: {
+                loaded: () => {
+                  return {
+                    type: "noop"
+                  }
+                }
+              }
+            }
+          }
+        })
+      ]
+    })
+    
+    resolve(system)
+  })
+}
+
+describe("editor metadata plugin", function() {
+  this.timeout(10 * 1000)
+
+  it("should provide a `getEditorMetadata` method", async () => {
+    const spec = {}
+
+    const system = await getSystem(spec)
+
+    expect(system.getEditorMetadata).toBeA(Function)
+  })
+
+  it("should return JS object spec content from the `getEditorMetadata` method", async () => {
+    const spec = {
+      swagger: "2.0",
+      paths: {
+        "/": {
+          get: {
+            description: "hello there!",
+            responses: {
+              "200": {
+                description: "ok"
+              }
+            }
+          }
+        }
+      }
+    }
+
+    const system = await getSystem(spec)
+
+    expect(system.getEditorMetadata().contentString).toEqual(`{"swagger":"2.0","paths":{"/":{"get":{"description":"hello there!","responses":{"200":{"description":"ok"}}}}}}`)
+    expect(system.getEditorMetadata().contentObject).toEqual(spec)
+  })
+
+
+  it("should return YAML string spec content from the `getEditorMetadata` method", async () => {
+    const spec = `---
+    swagger: '2.0'
+    paths:
+      "/":
+        get:
+          description: hello there!
+          responses:
+            '200':
+              description: ok`
+
+    const system = await getSystem()
+
+    system.specActions.updateSpec(spec)
+
+    expect(system.getEditorMetadata().contentString).toEqual(spec)
+    expect(system.getEditorMetadata().contentObject).toEqual({
+      swagger: "2.0",
+      paths: {
+        "/": {
+          get: {
+            description: "hello there!",
+            responses: {
+              "200": {
+                description: "ok"
+              }
+            }
+          }
+        }
+      }
+    })
+  })
+  
+  it("should return isValid for a valid spec", async () => {
+    const spec = {
+      swagger: "2.0",
+      paths: {
+        "/": {
+          get: {
+            description: "hello there!",
+            responses: {
+              "200": {
+                description: "ok"
+              }
+            }
+          }
+        }
+      }
+    }
+
+    const system = await getSystem(spec)
+
+    expect(system.getEditorMetadata().isValid).toBeA("boolean")
+    expect(system.getEditorMetadata().isValid).toBe(true)
+  })
+
+    
+  it("should return isValid for an invalid spec", async () => {
+    const spec = {
+      swagger: "2.0",
+      paths: {
+        "/": {
+          get: {
+            description: "hello there!",
+            responses: {
+              "200": {
+                description: "ok"
+              }
+            }
+          }
+        }
+      }
+    }
+
+    const err = {
+      type: "spec",
+      message: "it's broken!"
+    }
+
+    const system = await getSystem(spec)
+
+    system.errActions.newSpecErr(err)
+
+    expect(system.getEditorMetadata().isValid).toBeA("boolean")
+    expect(system.getEditorMetadata().isValid).toBe(false)
+    expect(system.getEditorMetadata().errors).toEqual([err])
+  })
+})

--- a/test/plugins/editor-metadata/index.js
+++ b/test/plugins/editor-metadata/index.js
@@ -1,5 +1,4 @@
 import expect from "expect"
-import throttle from "lodash/throttle"
 import SwaggerUi from "swagger-ui"
 import EditorMetadataPlugin from "plugins/editor-metadata"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This PR adds a `getEditorMetadata` method to Swagger Editor, which provides:
- definition content as a string and object
- validation state as a boolean
- array of errors registered in state

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #1590.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Five unit tests have been added 😄 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [x] My changes require a change to the project documentation.
- [x] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.