### PR TITLE
fix(semval): don't warn about Path Item $ref siblings

### DIFF
--- a/src/plugins/validate-semantic/validators/2and3/refs.js
+++ b/src/plugins/validate-semantic/validators/2and3/refs.js
@@ -12,10 +12,10 @@ export const validate2And3RefHasNoSiblings = () => system => {
       return nodes.reduce((acc, node) => {
         const unresolvedValue = get(specJson, node.parent.path) || {}
         const unresolvedKeys = Object.keys(unresolvedValue) || []
-
+        const isPathItem = node.parent.key === "paths" && node.path.length === 2
 
         unresolvedKeys.forEach(k => {
-          if(k !== "$ref" && unresolvedKeys.indexOf("$ref") > -1) {
+          if(!isPathItem && k !== "$ref" && unresolvedKeys.indexOf("$ref") > -1) {
             acc.push({
               message: `Sibling values are not allowed alongside $refs`,
               path: [...node.path.slice(0, -1), k],

--- a/test/plugins/validate-semantic/2and3/refs.js
+++ b/test/plugins/validate-semantic/2and3/refs.js
@@ -97,6 +97,45 @@ describe("validation plugin - semantic - 2and3 refs", function() {
       return expectNoErrorsOrWarnings(spec)
     })
 
+    it("should return no warnings when a path item $ref has siblings in OpenAPI 3", () => {
+      const spec = {
+        openapi: "3.0.0",
+        paths: {
+          $ref: "#/components/schemas/abc",
+          "/CoolPath": {
+            get: {
+              $ref: "#/components/schemas/abc"
+            }
+          }
+        },
+        components: {
+          schemas: {
+            abc: {}
+          }
+        }
+      }
+
+      return expectNoErrorsOrWarnings(spec)
+    })
+    it("should return no warnings when a path item $ref has siblings in Swagger 2", () => {
+      const spec = {
+        swagger: "2.0",
+        paths: {
+          $ref: "#/definitions/abc",
+          "/CoolPath": {
+            get: {
+              $ref: "#/definitions/abc"
+            }
+          }
+        },
+        definitions: {
+          abc: {}
+        }
+      }
+
+      return expectNoErrorsOrWarnings(spec)
+    })
+
   })
   describe("Unused definitions", () => {
     it("should return a warning when a definition is declared but not used in OpenAPI 3", () => {


### PR DESCRIPTION
Fixes #1493.