### PR TITLE
downgrade react-dropzone, as 4.2.12 shows blank screen.

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "react-addons-css-transition-group": "^15.4.2",
     "react-dd-menu": "^2.0.0",
     "react-dom": "^15.6.2",
-    "react-dropzone": "^4.2.7",
+    "react-dropzone": "4.2.11",
     "react-file-download": "^0.3.2",
     "react-redux": "^4.x.x",
     "react-transition-group": "^1.1.1",


### PR DESCRIPTION
fixes https://github.com/swagger-api/swagger-editor/issues/1812