### PR TITLE
fix: restore casing of editor plugin names

### DIFF
--- a/src/plugins/editor/editor-plugins/hook.js
+++ b/src/plugins/editor/editor-plugins/hook.js
@@ -4,9 +4,9 @@ import JsonToYaml from "./json-to-yaml"
 import TabHandler from "./tab-handler"
 
 const plugins = [
-  {fn: GutterClick, name: "GutterClick"},
-  {fn: JsonToYaml, name: "JsonToYaml"},
-  {fn: TabHandler, name: "TabHandler"},
+  {fn: GutterClick, name: "gutterClick"},
+  {fn: JsonToYaml, name: "jsonToYaml"},
+  {fn: TabHandler, name: "tabHandler"},
 ]
 
 export default function (editor, props = {}, editorPluginsToRun = [], helpers = {}) {


### PR DESCRIPTION
Fixes a bug introduced in #1764 that was preventing editor plugins from running

cc: @ponelat 