### PR TITLE
fix(autosuggest): double-escape Responses digit regex mask

### DIFF
--- a/src/plugins/editor-autosuggest-oas3-keywords/oas3-objects.js
+++ b/src/plugins/editor-autosuggest-oas3-keywords/oas3-objects.js
@@ -216,7 +216,7 @@ export const Response = {
 
 export const Responses = {
   default: anyOf(Response, Reference),
-  "\d\d\d|\d\dX|\dXX": anyOf(Response, Reference),
+  "\\d\\d\\d|\\d\\dX|\\dXX": anyOf(Response, Reference),
 }
 
 export const Callback = {


### PR DESCRIPTION
Fixes #1863.

> It's _perfect_.
> 
> -- me, on OAS3 autocomplete, July 7, 2017

It was perfect except for this one part that wasn't 😄 