### PR TITLE
fix: force HTTPS download session links for 2.0 io generator

### DIFF
--- a/src/standalone/topbar/topbar.jsx
+++ b/src/standalone/topbar/topbar.jsx
@@ -1,6 +1,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 import Swagger from "swagger-client"
+import URL from "url"
 import "whatwg-fetch"
 import DropdownMenu from "./DropdownMenu"
 import Modal from "boron/DropModal"
@@ -233,7 +234,16 @@ export default class Topbar extends React.Component {
       return console.error(res)
     }
 
-    fetch(res.body.link)
+    let downloadUrl = URL.parse(res.body.link)
+
+    // HACK: workaround for Swagger.io Generator 2.0's lack of HTTPS downloads
+    if(downloadUrl.hostname === "generator.swagger.io") {
+      downloadUrl.protocol = "https:"
+      delete downloadUrl.port
+      delete downloadUrl.host
+    }
+
+    fetch(URL.format(downloadUrl))
       .then(res => res.blob())
       .then(res => {
         this.downloadFile(res, `${name}-${type}-generated.zip`)

--- a/test/e2e/tests/.eslintrc
+++ b/test/e2e/tests/.eslintrc
@@ -1,0 +1,9 @@
+globals:
+  cy: false
+  Cypress: false
+  expect: false
+  assert: false
+
+rules:
+  "no-console": 0
+  "no-unused-vars": 0

--- a/test/e2e/tests/.eslintrc
+++ b/test/e2e/tests/.eslintrc
@@ -1,9 +1,0 @@
-globals:
-  cy: false
-  Cypress: false
-  expect: false
-  assert: false
-
-rules:
-  "no-console": 0
-  "no-unused-vars": 0

--- a/test/e2e/tests/bugs/1862.js
+++ b/test/e2e/tests/bugs/1862.js
@@ -1,0 +1,101 @@
+describe("Editor #1862: codegen download links downgrade HTTPS", () => {
+  describe("in Swagger 2", () => {
+    beforeEach(() => {
+      cy.visit("/?url=/documents/petstore.swagger.yaml")
+
+      cy.server()
+
+      cy.route({
+        url: "*//generator.swagger.io/api/gen/servers",
+        response: ["nodejs"]
+      })
+
+      cy.route({
+        url: "*//generator.swagger.io/api/gen/clients",
+        response: ["javascript"]
+      })
+    })
+
+    it("should force HTTPS server downloads from Swagger.io Generator", () => {
+      let wasHttpHit = false
+      let wasHttpsHit = false
+
+      // Given
+
+      cy.route({
+        url: "https://generator.swagger.io/api/gen/servers/nodejs",
+        method: "POST",
+        response: {
+          "code": "a92bc815-f6e3-4a56-839b-fd2e6f379d52",
+          "link": "http://generator.swagger.io:80/api/gen/download/a92bc815-f6e3-4a56-839b-fd2e6f379d52"
+        }
+      })
+
+      cy.route({
+        url: "http://generator.swagger.io/api/gen/download/*",
+        onRequest: () => wasHttpHit = true,
+        response: {}
+      })
+
+      cy.route({
+        url: "https://generator.swagger.io/api/gen/download/*",
+        onRequest: () => wasHttpsHit = true,
+        response: {}
+      })
+
+      // Then
+      cy.contains("Generate Server")
+        .click()
+
+      cy.contains("nodejs")
+        .click()
+
+      cy.wait(100)
+        .then(() => {
+          expect(wasHttpHit).to.equal(false, "has HTTP server been hit")
+          expect(wasHttpsHit).to.equal(true, "has HTTPS server been hit")
+        })
+    })
+
+    it("should force HTTPS client downloads from Swagger.io Generator", () => {
+      let wasHttpHit = false
+      let wasHttpsHit = false
+
+      // Given
+
+      cy.route({
+        url: "https://generator.swagger.io/api/gen/clients/javascript",
+        method: "POST",
+        response: {
+          "code": "a92bc815-f6e3-4a56-839b-fd2e6f379d52",
+          "link": "http://generator.swagger.io:80/api/gen/download/a92bc815-f6e3-4a56-839b-fd2e6f379d52"
+        }
+      })
+
+      cy.route({
+        url: "http://generator.swagger.io/api/gen/download/*",
+        onRequest: () => wasHttpHit = true,
+        response: {}
+      })
+
+      cy.route({
+        url: "https://generator.swagger.io/api/gen/download/*",
+        onRequest: () => wasHttpsHit = true,
+        response: {}
+      })
+
+      // Then
+      cy.contains("Generate Client")
+        .click()
+
+      cy.contains("javascript")
+        .click()
+
+      cy.wait(100)
+        .then(() => {
+          expect(wasHttpHit).to.equal(false, "has HTTP server been hit")
+          expect(wasHttpsHit).to.equal(true, "has HTTPS server been hit")
+        })
+    })
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This PR forces the Topbar to rewrite `generator.swagger.io` URLs as HTTPS over port 443, which fixes mixed content security violations when using the Editor with swagger.io's Generator service over HTTPS.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #1862.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I added Cypress tests (and Cypress itself!).

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
