### PR TITLE
fix wrong port in docker run as the container exposes 8080 and not 80

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To use this, run the following:
 
 ```
 docker pull swaggerapi/swagger-editor
-docker run -d -p 80:8080 swaggerapi/swagger-editor
+docker run -d -p 8080:8080 swaggerapi/swagger-editor
 ```
 
 This will run Swagger Editor (in detached mode) on port 80 on your machine, so you can open it by navigating to `http://localhost` in your browser.


### PR DESCRIPTION

### Description
Whe using the todays latest docker container to run the editor the documentation uses the wrong port. Based on the Dockerbuild file it's 8080. But in the readme port 80 was used.