### PR TITLE
fix(validation): allow inherited parameters to overwrite without flagging as invalid

### DIFF
--- a/src/plugins/validate-semantic/validators/2and3/parameters.js
+++ b/src/plugins/validate-semantic/validators/2and3/parameters.js
@@ -73,8 +73,3 @@ export const validate2And3ParameterDefaultsMatchAnEnum = () => (system) => {
       }, [])
     })
 }
-
-function preserveOriginalIndices(obj, i) {
-  obj.__i = i
-  return obj
-}

--- a/src/plugins/validate-semantic/validators/2and3/parameters.js
+++ b/src/plugins/validate-semantic/validators/2and3/parameters.js
@@ -4,31 +4,8 @@ export const validate2And3ParametersHaveUniqueNameAndInCombinations = () => (sys
     .then(nodes => {
       return nodes.reduce((acc, node) => {
         const parameters = node.node || []
-        const isOperationParameters = system.validateSelectors.isOperationParameters(node)
-
-        var inheritedParameters = []
-
-        if(isOperationParameters) {
-          const pathItemParameters = (node.parent.parent.node.parameters || [])
-            .map(preserveOriginalIndices)
-
-          inheritedParameters = [...pathItemParameters]
-        } else {
-          inheritedParameters = []
-        }
 
         const seen = []
-
-        inheritedParameters.forEach(param => {
-          const { name: paramName, in: paramIn } = param
-
-          if(!paramName || !paramIn) {
-            // name or in is missing, so we can't match the param to anything else
-            return
-          }
-          const key = `${paramName}::${paramIn}`
-          seen.push(key)
-        })
 
         parameters.forEach((param, i) => {
           const { name: paramName, in: paramIn } = param
@@ -41,7 +18,7 @@ export const validate2And3ParametersHaveUniqueNameAndInCombinations = () => (sys
           if(seen.indexOf(key) > -1) {
             acc.push({
               level: "error",
-              message: "Sibling parameters, whether inherited or direct, must have unique name + in values",
+              message: "Sibling parameters must have unique name + in values",
               path: [
                 ...node.path,
                 (param.__i || i).toString()

--- a/test/unit/plugins/validate-semantic/2and3/parameters.js
+++ b/test/unit/plugins/validate-semantic/2and3/parameters.js
@@ -9,16 +9,30 @@ describe(`validation plugin - semantic - 2and3 parameters`, () => {
           swagger: "2.0",
           "paths": {
             "/pets": {
+              "parameters": [
+                {
+                  "name": "pathLevel",
+                  "in": "query",
+                  "description": "tags to filter by",
+                  "type": "string"
+                },
+                {
+                  "name": "pathLevel",
+                  "in": "query",
+                  "description": "tags to filter by",
+                  "type": "string"
+                },
+              ],
               "get": {
                 "parameters": [
                   {
-                    "name": "tags",
+                    "name": "opLevel",
                     "in": "query",
                     "description": "tags to filter by",
                     "type": "string"
                   },
                   {
-                    "name": "tags",
+                    "name": "opLevel",
                     "in": "query",
                     "description": "tags to filter by",
                     "type": "string"
@@ -33,9 +47,12 @@ describe(`validation plugin - semantic - 2and3 parameters`, () => {
         .then(system => {
           const allErrors = system.errSelectors.allErrors().toJS()
           const firstError = allErrors[0]
-          expect(allErrors.length).toEqual(1)
-          expect(firstError.path).toEqual(["paths", "/pets", "get", "parameters", "1"])
+          const secondError = allErrors[1]
+          expect(allErrors.length).toEqual(2)
+          expect(firstError.path).toEqual(["paths", "/pets", "parameters", "1"])
           expect(firstError.message).toEqual("Sibling parameters must have unique name + in values")
+          expect(secondError.path).toEqual(["paths", "/pets", "get", "parameters", "1"])
+          expect(secondError.message).toEqual("Sibling parameters must have unique name + in values")
         })
       })
       it("should return an error for an invalid OpenAPI 3 definition", () => {
@@ -43,19 +60,41 @@ describe(`validation plugin - semantic - 2and3 parameters`, () => {
           openapi: "3.0.0",
           "paths": {
             "/pets": {
+              "parameters": [
+                {
+                  "name": "pathLevel",
+                  "in": "query",
+                  "description": "tags to filter by",
+                  "schema": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "name": "pathLevel",
+                  "in": "query",
+                  "description": "tags to filter by",
+                  "schema": {
+                    "type": "string"
+                  }
+                },
+              ],
               "get": {
                 "parameters": [
                   {
-                    "name": "tags",
+                    "name": "opLevel",
                     "in": "query",
                     "description": "tags to filter by",
-                    "type": "string"
+                    "schema": {
+                      "type": "string"
+                    }
                   },
                   {
-                    "name": "tags",
+                    "name": "opLevel",
                     "in": "query",
                     "description": "tags to filter by",
-                    "type": "string"
+                    "schema": {
+                      "type": "string"
+                    }
                   },
                 ]
               }
@@ -67,9 +106,12 @@ describe(`validation plugin - semantic - 2and3 parameters`, () => {
         .then(system => {
           const allErrors = system.errSelectors.allErrors().toJS()
           const firstError = allErrors[0]
-          expect(allErrors.length).toEqual(1)
-          expect(firstError.path).toEqual(["paths", "/pets", "get", "parameters", "1"])
+          const secondError = allErrors[1]
+          expect(allErrors.length).toEqual(2)
+          expect(firstError.path).toEqual(["paths", "/pets", "parameters", "1"])
           expect(firstError.message).toEqual("Sibling parameters must have unique name + in values")
+          expect(secondError.path).toEqual(["paths", "/pets", "get", "parameters", "1"])
+          expect(secondError.message).toEqual("Sibling parameters must have unique name + in values")
         })
       })
       it("should return no errors for a valid Swagger 2 definition", () => {

--- a/test/unit/plugins/validate-semantic/2and3/parameters.js
+++ b/test/unit/plugins/validate-semantic/2and3/parameters.js
@@ -1,7 +1,7 @@
 import expect from "expect"
 import validateHelper from "../validate-helper.js"
 
-describe.only(`validation plugin - semantic - 2and3 parameters`, () => {
+describe(`validation plugin - semantic - 2and3 parameters`, () => {
   describe(`parameters must have unique name + in values`, () => {
     describe(`direct siblings`, () => {
       it("should return an error for an invalid Swagger 2 definition", () => {

--- a/test/unit/plugins/validate-semantic/2and3/parameters.js
+++ b/test/unit/plugins/validate-semantic/2and3/parameters.js
@@ -1,7 +1,7 @@
 import expect from "expect"
 import validateHelper from "../validate-helper.js"
 
-describe(`validation plugin - semantic - 2and3 parameters`, () => {
+describe.only(`validation plugin - semantic - 2and3 parameters`, () => {
   describe(`parameters must have unique name + in values`, () => {
     describe(`direct siblings`, () => {
       it("should return an error for an invalid Swagger 2 definition", () => {
@@ -35,7 +35,7 @@ describe(`validation plugin - semantic - 2and3 parameters`, () => {
           const firstError = allErrors[0]
           expect(allErrors.length).toEqual(1)
           expect(firstError.path).toEqual(["paths", "/pets", "get", "parameters", "1"])
-          expect(firstError.message).toEqual("Sibling parameters, whether inherited or direct, must have unique name + in values")
+          expect(firstError.message).toEqual("Sibling parameters must have unique name + in values")
         })
       })
       it("should return an error for an invalid OpenAPI 3 definition", () => {
@@ -69,7 +69,7 @@ describe(`validation plugin - semantic - 2and3 parameters`, () => {
           const firstError = allErrors[0]
           expect(allErrors.length).toEqual(1)
           expect(firstError.path).toEqual(["paths", "/pets", "get", "parameters", "1"])
-          expect(firstError.message).toEqual("Sibling parameters, whether inherited or direct, must have unique name + in values")
+          expect(firstError.message).toEqual("Sibling parameters must have unique name + in values")
         })
       })
       it("should return no errors for a valid Swagger 2 definition", () => {
@@ -136,7 +136,7 @@ describe(`validation plugin - semantic - 2and3 parameters`, () => {
       })
     })
     describe(`inherited siblings`, () => {
-      it("should return an error for an invalid Swagger 2 definition due to direct ancestor inheritance", () => {
+      it("should return no errors for a valid Swagger 2 definition due to inheritance", () => {
         const spec = {
           swagger: "2.0",
           parameters: {
@@ -176,15 +176,10 @@ describe(`validation plugin - semantic - 2and3 parameters`, () => {
         return validateHelper(spec)
         .then(system => {
           const allErrors = system.errSelectors.allErrors().toJS()
-          expect(allErrors.length).toEqual(1)
-          const firstError = allErrors[0]
-          expect(firstError).toInclude({
-            path: ["paths", "/pets", "get", "parameters", "0"],
-            message: "Sibling parameters, whether inherited or direct, must have unique name + in values"
-          })
+          expect(allErrors.length).toEqual(0)
         })
       })
-      it("should return an error for an invalid OpenAPI 3 definition due to direct ancestor inheritance", () => {
+      it("should return no errors for a valid OpenAPI 3 definition due to inheritance", () => {
         const spec = {
           openapi: "3.0.0",
           parameters: {
@@ -224,12 +219,7 @@ describe(`validation plugin - semantic - 2and3 parameters`, () => {
         return validateHelper(spec)
         .then(system => {
           const allErrors = system.errSelectors.allErrors().toJS()
-          expect(allErrors.length).toEqual(1)
-          const firstError = allErrors[0]
-          expect(firstError).toInclude({
-            path: ["paths", "/pets", "get", "parameters", "0"],
-            message: "Sibling parameters, whether inherited or direct, must have unique name + in values"
-          })
+          expect(allErrors.length).toEqual(0)
         })
       })
       it("should not return an error for root parameters in Swagger 2", () => {


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->

This PR modifies the `Sibling parameters must have unique name + in values` semantic validator to not take inherited (i.e., path-level) parameters into account when searching for duplicate name + in combinations.

This makes the validator more accurate (see OpenAPI Specification quote below) and its implementation more clear - everybody wins!

> `parameters`: a list of parameters that are applicable for this operation. If a parameter is already defined at the Path Item, the new definition will override it, but can never remove it. The list MUST NOT include duplicated parameters.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #1738.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Automated tests. Also tested against the [Bitbucket API](
https://bitbucket.org/api/swagger.json), and this snippet:

```yaml
swagger: "2.0"
info:
  title: Simple test
  description: Wow so simple
  version: "1.0"
paths:
  /simple:
    parameters: 
    - name: myParam
      in: query
      type: string
    get:
      summary: Get text
      description: Return simple plain text
      operationId: getText
      parameters: 
      - name: myParam
        in: query
        type: boolean
      responses:
        200:
          description: Text
```

Validation accuracy as well is UI Try-It-Out functionality was checked.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.