### PR TITLE
housekeeping(docker): tighten application server security directives

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -26,31 +26,6 @@ http {
     location / {
       root            /usr/share/nginx/html;
       index           index.html index.htm;
-      if ($request_method = 'OPTIONS') {
-          add_header 'Access-Control-Allow-Origin' '*';
-          add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-          #
-          # Custom headers and headers various browsers *should* be OK with but aren't
-          #
-          add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
-          #
-          # Tell client that this pre-flight info is valid for 20 days
-          #
-          add_header 'Access-Control-Max-Age' 1728000;
-          add_header 'Content-Type' 'text/plain charset=UTF-8';
-          add_header 'Content-Length' 0;
-          return 204;
-      }
-      if ($request_method = 'POST') {
-          add_header 'Access-Control-Allow-Origin' '*';
-          add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-          add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
-      }
-      if ($request_method = 'GET') {
-          add_header 'Access-Control-Allow-Origin' '*';
-          add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-          add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
-      }
     }
   }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -18,6 +18,8 @@ http {
 
   gzip_vary on;
   gzip_types text/plain text/css application/javascript;
+  
+  add_header X-Frame-Options deny;
 
   server {
     listen            8080;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR adds and removes some behaviors in the application server that makes Swagger Editor available within our Docker container.

Specifically...

#### 🚫 CORS directives have been removed

They didn't serve any discernible purpose, since the server doesn't expose any useful API endpoints.

#### 🖼 `X-Frame-Options: Deny` has been added

This header prevents Swagger Editor Docker deployments from being embedded via iframe (et al), which should prevent [clickjacking attacks](https://javascript.info/clickjacking).

While Swagger Editor isn't a particularly high-value target (or easily targetable via in a clickjacking scenario), we don't have a documented use case for iframes being useful -- let's close the door on this until/unless we do.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

These issues were raised as part of a security audit - that's all I'm at liberty to say 😄 

None of the changes are high-impact w/r/t security, so the normal disclosure and release procedures won't apply here.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.