### PR TITLE
2049 - New Validation added for parameters checking casing matches.

### DIFF
--- a/src/plugins/validate-semantic/validators/2and3/paths.js
+++ b/src/plugins/validate-semantic/validators/2and3/paths.js
@@ -47,7 +47,7 @@ export const validate2And3PathParameterDeclarationHasMatchingDefiniton = () => a
           })
         } else if(res.caseMatch) {
           acc.push({
-            message: `Parameter names are case-sensitive. The parameter named "${paramName}" does not match the case used in the path "${node.key}".`,
+            message: `Parameter names are case-sensitive. The parameter named "${res.paramCase}" does not match the case used in the path "${node.key}".`,
             path: [...node.path],
             level: "error",
           })

--- a/src/plugins/validate-semantic/validators/2and3/paths.js
+++ b/src/plugins/validate-semantic/validators/2and3/paths.js
@@ -45,6 +45,12 @@ export const validate2And3PathParameterDeclarationHasMatchingDefiniton = () => a
             path: [...node.path],
             level: "error",
           })
+        } else if(res.caseMatch) {
+          acc.push({
+            message: `Parameter names are case-sensitive. The parameter named "${paramName}" does not match the case used in the path "${node.key}".`,
+            path: [...node.path],
+            level: "error",
+          })
         } else if(!res.found) {
           acc.push({
             message: `Declared path parameter "${paramName}" needs to be defined as a path parameter at either the path or operation level`,

--- a/src/plugins/validate-semantic/validators/helpers.js
+++ b/src/plugins/validate-semantic/validators/helpers.js
@@ -16,6 +16,7 @@ export function checkForDefinition(paramName, pathItem) {
     found: false,
     inPath: false,
     inOperation: false,
+    caseMatch: false,
     missingFromOperations: []
   }
 
@@ -36,9 +37,16 @@ export function checkForDefinition(paramName, pathItem) {
         const inThisOperation = (op.parameters || [])
           .some(param => param.name === paramName && param.in === "path")
 
+        const caseMatch = (op.parameters || [])
+        .some(param => !(param.name === paramName) && (param.name.toLowerCase() === paramName.toLowerCase()) && param.in === "path")
+
         if(inThisOperation) {
           res.found = true
           res.inOperation = true
+        }
+
+        if(caseMatch) {
+          res.caseMatch = true
         }
 
         if(!inThisOperation) {

--- a/src/plugins/validate-semantic/validators/helpers.js
+++ b/src/plugins/validate-semantic/validators/helpers.js
@@ -17,6 +17,7 @@ export function checkForDefinition(paramName, pathItem) {
     inPath: false,
     inOperation: false,
     caseMatch: false,
+    paramCase: "",
     missingFromOperations: []
   }
 
@@ -38,7 +39,7 @@ export function checkForDefinition(paramName, pathItem) {
           .some(param => param.name === paramName && param.in === "path")
 
         const caseMatch = (op.parameters || [])
-        .some(param => !(param.name === paramName) && (param.name.toLowerCase() === paramName.toLowerCase()) && param.in === "path")
+        .find(param => !(param.name === paramName) && (param.name.toLowerCase() === paramName.toLowerCase()) && param.in === "path")
 
         if(inThisOperation) {
           res.found = true
@@ -47,6 +48,7 @@ export function checkForDefinition(paramName, pathItem) {
 
         if(caseMatch) {
           res.caseMatch = true
+          res.paramCase = caseMatch.name
         }
 
         if(!inThisOperation) {

--- a/test/unit/plugins/validate-semantic/2and3/paths.js
+++ b/test/unit/plugins/validate-semantic/2and3/paths.js
@@ -426,6 +426,36 @@ describe("validation plugin - semantic - 2and3 paths", () => {
             expect(firstError.path).toEqual(["paths", "/CoolPath/{id}"])
           })
         })
+
+        it("should return a specific error for parameters with different casing characters OpenAPI 3 definition", () => {
+          const spec = {
+            openapi: "3.0.1",
+            "paths": {
+              "/{myParam}": {
+                "get": {
+                  "parameters": [
+                    {
+                      "name": "myparam",
+                      "in": "path",
+                      "required": true,
+                      "schema": {
+                        "type": "string"
+                      }
+                    },
+                  ]
+                }
+              }
+            }
+          }
+  
+          return validateHelper(spec)
+            .then(system => {
+              const allErrors = system.errSelectors.allErrors().toJS()
+              const firstError = allErrors[0]
+              expect(allErrors.length).toEqual(1)
+              expect(firstError.message).toEqual("Parameter names are case-sensitive. The parameter named \"myParam\" does not match the case used in the path \"/{myParam}\".")    
+            })
+        })
       })
 
     })

--- a/test/unit/plugins/validate-semantic/2and3/paths.js
+++ b/test/unit/plugins/validate-semantic/2and3/paths.js
@@ -453,10 +453,32 @@ describe("validation plugin - semantic - 2and3 paths", () => {
               const allErrors = system.errSelectors.allErrors().toJS()
               const firstError = allErrors[0]
               expect(allErrors.length).toEqual(1)
-              expect(firstError.message).toEqual("Parameter names are case-sensitive. The parameter named \"myParam\" does not match the case used in the path \"/{myParam}\".")    
+              expect(firstError.message).toEqual("Parameter names are case-sensitive. The parameter named \"myparam\" does not match the case used in the path \"/{myParam}\".")    
             })
         })
       })
 
+      it("should return no errors for parameters with same characters in path and parameters definition", () => {
+        const spec = {
+          openapi: "3.0.1",
+          "paths": {
+            "/{myParam}": {
+              "get": {
+                "parameters": [
+                  {
+                    "name": "myParam",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                      "type": "string"
+                    }
+                  },
+                ]
+              }
+            }
+          }
+        }
+        return expectNoErrors(spec)
+      })
     })
 })


### PR DESCRIPTION
2049 - New Validation added for parameters checking casing matches, test added.



### Description
New Validation Added for this ticket: Path parameter validation should be smart about improper casing #2049 
When parameters have the same characters but different casing scenarios compared with path elements you will be able to see this message: 
In this case we have a Petid parameter, and petid as path parameter.
Parameter names are case-sensitive. The parameter named Petid does not match the case used in the 
path /pets/{petId}.



### Motivation and Context

This fixes the issue: https://github.com/swagger-api/swagger-editor/issues/2049


### How Has This Been Tested?
I added a test case in paths.js to validate this, and also did manual testing with swagger-editor tool.


### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
