### PR TITLE
2048 - Sibling Ref - Message updated and tests added

### DIFF
--- a/src/plugins/validate-semantic/validators/2and3/refs.js
+++ b/src/plugins/validate-semantic/validators/2and3/refs.js
@@ -17,7 +17,7 @@ export const validate2And3RefHasNoSiblings = () => system => {
         unresolvedKeys.forEach(k => {
           if(!isPathItem && k !== "$ref" && unresolvedKeys.indexOf("$ref") > -1) {
             acc.push({
-              message: `Sibling values are not allowed alongside $refs`,
+              message: `Sibling values alongside $refs are ignored.\nTo add properties to a $ref, wrap the $ref into allOf, or move the extra properties into the referenced definition (if applicable).`,
               path: [...node.path.slice(0, -1), k],
               level: "warning"
             })

--- a/test/unit/plugins/validate-semantic/2and3/refs.js
+++ b/test/unit/plugins/validate-semantic/2and3/refs.js
@@ -28,7 +28,7 @@ describe("validation plugin - semantic - 2and3 refs", function() {
         const allErrors = system.errSelectors.allErrors().toJS()
         expect(allErrors.length).toEqual(1)
         const firstError = allErrors[0]
-        expect(firstError.message).toMatch("Sibling values are not allowed alongside $refs")
+        expect(firstError.message).toMatch("Sibling values alongside $refs are ignored.\nTo add properties to a $ref, wrap the $ref into allOf, or move the extra properties into the referenced definition (if applicable).")
         expect(firstError.level).toEqual("warning")
         expect(firstError.path).toEqual(["paths", "/CoolPath", "get", "description"])
       })
@@ -54,7 +54,7 @@ describe("validation plugin - semantic - 2and3 refs", function() {
         const allErrors = system.errSelectors.allErrors().toJS()
         expect(allErrors.length).toEqual(1)
         const firstError = allErrors[0]
-        expect(firstError.message).toMatch("Sibling values are not allowed alongside $refs")
+        expect(firstError.message).toMatch("Sibling values alongside $refs are ignored.\nTo add properties to a $ref, wrap the $ref into allOf, or move the extra properties into the referenced definition (if applicable).")
         expect(firstError.level).toEqual("warning")
         expect(firstError.path).toEqual(["paths", "/CoolPath", "get", "description"])
       })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Warning message updated, also changed tests for fixing this issue: https://github.com/swagger-api/swagger-editor/issues/2048. 
### Description
<!--- Describe your changes in detail -->
Update a simple warning message and tests.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
Trying to fix the issue https://github.com/swagger-api/swagger-editor/issues/2048


### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Previous tests changed with new message. 


### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
