### PR TITLE
improve: `getPathForPosition` array member fragment preparation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5355,6 +5355,12 @@
         "mimic-response": "^1.0.0"
       }
     },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
+    },
     "deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
@@ -7968,7 +7974,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7989,12 +7996,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8009,17 +8018,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8136,7 +8148,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8148,6 +8161,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8162,6 +8176,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8169,12 +8184,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8193,6 +8210,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8273,7 +8291,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8285,6 +8304,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8370,7 +8390,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8406,6 +8427,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8425,6 +8447,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8468,12 +8491,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "css-loader": "^3.1.0",
     "cssnano": "^4.1.10",
     "cypress": "^3.4.1",
+    "dedent": "^0.7.0",
     "deep-extend": "^0.6.0",
     "deepmerge": "^1.3.2",
     "enzyme": "^3.3.0",

--- a/src/plugins/ast/ast.js
+++ b/src/plugins/ast/ast.js
@@ -194,9 +194,9 @@ export function pathForPosition(yaml, position) {
 
     const problemMark = e.problem_mark || {}
     const errorTraceMessage = [
-      yaml.split("\n").slice(problemMark.line - 5, problemMark.line).join("\n"),
+      yaml.split("\n").slice(problemMark.line - 5, problemMark.line + 1).join("\n"),
       Array(problemMark.column).fill(" ").join("") + `^----- ${e.name}: ${e.toString().split("\n")[0]}`,
-      yaml.split("\n").slice(problemMark.line, problemMark.line + 5).join("\n")
+      yaml.split("\n").slice(problemMark.line + 1, problemMark.line + 5).join("\n")
     ].join("\n")
 
     console.error(errorTraceMessage)

--- a/src/plugins/editor-autosuggest/fn.js
+++ b/src/plugins/editor-autosuggest/fn.js
@@ -15,7 +15,13 @@ export function getPathForPosition({ pos: originalPos, prefix, editorValue, AST 
   let prevLineIndent = getIndent(previousLine).length
   let currLineIndent = getIndent(currentLine).length
 
-  if((previousLine.trim()[0] === "-" || nextLine.trim()[0] === "-") && currLineIndent >= prevLineIndent) {
+  const isCurrentLineEmpty = currentLine.replace(prefix, "").trim() === ""
+
+  if(
+    (previousLine.trim()[0] === "-" || nextLine.trim()[0] === "-")
+    && currLineIndent >= prevLineIndent
+    && isCurrentLineEmpty
+  ) {
     // for arrays with existing items under it, on blank lines
     // example:
     // myArray:

--- a/src/plugins/editor-autosuggest/fn.js
+++ b/src/plugins/editor-autosuggest/fn.js
@@ -35,7 +35,7 @@ export function getPathForPosition({ pos: originalPos, prefix, editorValue, AST 
   // if current position is in at a free line with whitespace insert a fake
   // key value pair so the generated AST in ASTManager has current position in
   // editing node
-  if ( !prepared && currentLine.replace(prefix, "").trim() === "") {
+  if ( !prepared && isCurrentLineEmpty) {
     currentLine += "a: b" // fake key value pair
     pos.column += 1
     prepared = true

--- a/test/unit/plugins/editor-autosuggest/fn.js
+++ b/test/unit/plugins/editor-autosuggest/fn.js
@@ -43,7 +43,7 @@ describe("Editor Autosuggest Plugin", function() {
       expect(AST.pathForPosition).toHaveBeenCalled()
 
       const [preparedEditorValue] = AST.pathForPosition.calls[0].arguments
-      expect(preparedEditorValue).toEqual(editorValue + ' ~')
+      expect(preparedEditorValue).toEqual(editorValue + " ~")
     })
   })
 })

--- a/test/unit/plugins/editor-autosuggest/fn.js
+++ b/test/unit/plugins/editor-autosuggest/fn.js
@@ -1,0 +1,49 @@
+import expect, { createSpy } from "expect"
+import dedent from "dedent"
+import { getPathForPosition } from "src/plugins/editor-autosuggest/fn.js"
+
+describe("Editor Autosuggest Plugin", function() {
+  describe("getPathForPosition - YAML value preparation", function() {
+    it.skip("should not modify a valid simple map", function() {
+      // Given
+      const editorValue = dedent(`
+        a: "one"
+        b: "two"
+      `)
+      const pos = { row: 0, col: 0 }
+      const AST = {
+        pathForPosition: createSpy()
+      }
+
+      // When
+      getPathForPosition({ editorValue, pos, prefix: "", AST })
+
+      // Then
+      expect(AST.pathForPosition).toHaveBeenCalled()
+
+      const [preparedEditorValue] = AST.pathForPosition.calls[0].arguments
+      expect(preparedEditorValue).toEqual(editorValue) // should be unchanged
+    })
+    it("should modify an array member map fragment", function() {
+      // Given
+      const editorValue = dedent(`
+        myArray:
+        - one: "abc"
+        - two: 
+      `)
+      const pos = { row: 2, col: 6 }
+      const AST = {
+        pathForPosition: createSpy()
+      }
+
+      // When
+      getPathForPosition({ editorValue, pos, prefix: "", AST })
+
+      // Then
+      expect(AST.pathForPosition).toHaveBeenCalled()
+
+      const [preparedEditorValue] = AST.pathForPosition.calls[0].arguments
+      expect(preparedEditorValue).toEqual(editorValue + ' ~')
+    })
+  })
+})


### PR DESCRIPTION
This PR modifies `getPathForPosition`'s preparation logic to only insert a fake `- a: b` array member if the user's current line is empty (excluding the already-typed autosuggest prefix), which fixes some edge cases in which we were overzealously inserting array members within array member fragments, e.g.:

```yaml
myArray:
  - one: "abc"
  - two: 
```

...would previously be prepared to this invalid YAML:

```yaml
myArray:
  - one: "abc"
  - two: - a: b
```

...but with this change, will generate this valid prepared YAML instead:

```yaml
myArray:
  - one: "abc"
  - two: ~
```

---

In terms of testing:
* `getPathForPosition` unit tests have been added for ~all code branches, as well as~ the edge case in quesiton
* I've tested these changes manually using the Petstore definition