### PR TITLE
replace numeric keys in yaml files with strings

### DIFF
--- a/src/plugins/local-storage/petstore.js
+++ b/src/plugins/local-storage/petstore.js
@@ -54,7 +54,7 @@ paths:
         schema:
           $ref: "#/definitions/Pet"
       responses:
-        405:
+        "405":
           description: "Invalid input"
       security:
       - petstore_auth:
@@ -80,11 +80,11 @@ paths:
         schema:
           $ref: "#/definitions/Pet"
       responses:
-        400:
+        "400":
           description: "Invalid ID supplied"
-        404:
+        "404":
           description: "Pet not found"
-        405:
+        "405":
           description: "Validation exception"
       security:
       - petstore_auth:
@@ -115,13 +115,13 @@ paths:
           default: "available"
         collectionFormat: "multi"
       responses:
-        200:
+        "200":
           description: "successful operation"
           schema:
             type: "array"
             items:
               $ref: "#/definitions/Pet"
-        400:
+        "400":
           description: "Invalid status value"
       security:
       - petstore_auth:
@@ -148,13 +148,13 @@ paths:
           type: "string"
         collectionFormat: "multi"
       responses:
-        200:
+        "200":
           description: "successful operation"
           schema:
             type: "array"
             items:
               $ref: "#/definitions/Pet"
-        400:
+        "400":
           description: "Invalid tag value"
       security:
       - petstore_auth:
@@ -179,13 +179,13 @@ paths:
         type: "integer"
         format: "int64"
       responses:
-        200:
+        "200":
           description: "successful operation"
           schema:
             $ref: "#/definitions/Pet"
-        400:
+        "400":
           description: "Invalid ID supplied"
-        404:
+        "404":
           description: "Pet not found"
       security:
       - api_key: []
@@ -218,7 +218,7 @@ paths:
         required: false
         type: "string"
       responses:
-        405:
+        "405":
           description: "Invalid input"
       security:
       - petstore_auth:
@@ -245,9 +245,9 @@ paths:
         type: "integer"
         format: "int64"
       responses:
-        400:
+        "400":
           description: "Invalid ID supplied"
-        404:
+        "404":
           description: "Pet not found"
       security:
       - petstore_auth:
@@ -282,7 +282,7 @@ paths:
         required: false
         type: "file"
       responses:
-        200:
+        "200":
           description: "successful operation"
           schema:
             $ref: "#/definitions/ApiResponse"
@@ -301,7 +301,7 @@ paths:
       - "application/json"
       parameters: []
       responses:
-        200:
+        "200":
           description: "successful operation"
           schema:
             type: "object"
@@ -328,11 +328,11 @@ paths:
         schema:
           $ref: "#/definitions/Order"
       responses:
-        200:
+        "200":
           description: "successful operation"
           schema:
             $ref: "#/definitions/Order"
-        400:
+        "400":
           description: "Invalid Order"
   /store/order/{orderId}:
     get:
@@ -355,13 +355,13 @@ paths:
         minimum: 1.0
         format: "int64"
       responses:
-        200:
+        "200":
           description: "successful operation"
           schema:
             $ref: "#/definitions/Order"
-        400:
+        "400":
           description: "Invalid ID supplied"
-        404:
+        "404":
           description: "Order not found"
     delete:
       tags:
@@ -382,9 +382,9 @@ paths:
         minimum: 1.0
         format: "int64"
       responses:
-        400:
+        "400":
           description: "Invalid ID supplied"
-        404:
+        "404":
           description: "Order not found"
   /user:
     post:
@@ -472,7 +472,7 @@ paths:
         required: true
         type: "string"
       responses:
-        200:
+        "200":
           description: "successful operation"
           schema:
             type: "string"
@@ -485,7 +485,7 @@ paths:
               type: "string"
               format: "date-time"
               description: "date in UTC when token expires"
-        400:
+        "400":
           description: "Invalid username/password supplied"
   /user/logout:
     get:
@@ -518,13 +518,13 @@ paths:
         required: true
         type: "string"
       responses:
-        200:
+        "200":
           description: "successful operation"
           schema:
             $ref: "#/definitions/User"
-        400:
+        "400":
           description: "Invalid username supplied"
-        404:
+        "404":
           description: "User not found"
     put:
       tags:
@@ -548,9 +548,9 @@ paths:
         schema:
           $ref: "#/definitions/User"
       responses:
-        400:
+        "400":
           description: "Invalid user supplied"
-        404:
+        "404":
           description: "User not found"
     delete:
       tags:
@@ -568,9 +568,9 @@ paths:
         required: true
         type: "string"
       responses:
-        400:
+        "400":
           description: "Invalid username supplied"
-        404:
+        "404":
           description: "User not found"
 securityDefinitions:
   petstore_auth:

--- a/test/unit/plugins/json-schema-validator/test-documents/1511.yaml
+++ b/test/unit/plugins/json-schema-validator/test-documents/1511.yaml
@@ -19,7 +19,7 @@ input:
           required: true
           example: ok
         responses:
-          200:
+          "200":
             description: Ok
 output:
   length: 1

--- a/test/unit/plugins/json-schema-validator/test-documents/1519.yaml
+++ b/test/unit/plugins/json-schema-validator/test-documents/1519.yaml
@@ -29,7 +29,7 @@ cases:
                       type: string
                       required: true
           responses:
-            200:
+            "200":
               description: ok
   output:
     length: 2

--- a/test/unit/plugins/json-schema-validator/test-documents/1853.yaml
+++ b/test/unit/plugins/json-schema-validator/test-documents/1853.yaml
@@ -12,7 +12,7 @@ input:
         summary: Get a single contact by Id
         operationId: getContactById
         responses:
-          200:
+          "200":
             description: ok
         parameters: 
           - name: contactId

--- a/test/unit/plugins/json-schema-validator/test-documents/response-schema-restrictions.yaml
+++ b/test/unit/plugins/json-schema-validator/test-documents/response-schema-restrictions.yaml
@@ -9,7 +9,7 @@ cases:
       /:
         get:
           responses:
-            200:
+            "200":
               description: ""
               schema:
                 $ref: "abc"
@@ -32,7 +32,7 @@ cases:
       /:
         get:
           responses:
-            200:
+            "200":
               description: ""
               schema:
                 type: blah
@@ -52,7 +52,7 @@ cases:
       /:
         get:
           responses:
-            200:
+            "200":
               description: ""
               schema:
                 properties:
@@ -74,7 +74,7 @@ cases:
       /:
         get:
           responses:
-            200:
+            "200":
               description: ""
               schema:
                 properties:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
I have replaced numeric keys in OpenAPI documents with strings, in accordance with the OpenAPI spec.

### Motivation and Context

The OpenAPI spec requires that OpenAPI documents be expressable in JSON ([v2](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#format) and [v3](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#format)). YAML allows any type to be an object key, but OpenAPI does not. v3 has an explicit note to this effect in its Format section; it applies to v2 as well.

I think swagger-editor _should_ show an error when given YAML with non-string keys, but that doesn't look possible. The YAML parser (js-yaml) silently stringifies any object keys which are not strings, so swagger-editor's internals never see the integer keys. This is not the usual behavior of YAML parsers (and arguably not correct). I've opened an issue about this at [nodeca/js-yaml#538](https://github.com/nodeca/js-yaml/issues/538), but that's beyond the scope of this issue.

Pending that issue, swagger-editor can at least be fixed to not show an invalid API document when you open the editor.

This has come up over at [OAI/OpenAPI-Specification#2171](https://github.com/OAI/OpenAPI-Specification/issues/2171)

and https://github.com/stoplightio/spectral/issues/955

### How Has This Been Tested?

Given the YAML parser gives identical results parsing string and integer keys, and that's all I've changed, no tests or code should need any change.

## Checklist

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
