### PR TITLE
fix #1943 page refresh with local storage should validate only once

### DIFF
--- a/src/plugins/local-storage/index.js
+++ b/src/plugins/local-storage/index.js
@@ -13,7 +13,7 @@ export default function(system) {
   // setTimeout runs on the next tick
   setTimeout(() => {
     if(localStorage.getItem(CONTENT_KEY)) {
-      system.specActions.updateSpec(localStorage.getItem(CONTENT_KEY))
+      system.specActions.updateSpec(localStorage.getItem(CONTENT_KEY), "local-storage")
     } else if(localStorage.getItem("ngStorage-SwaggerEditorCache")) {
       // Legacy migration for swagger-editor 2.x
       try {

--- a/src/plugins/validate-semantic/index.js
+++ b/src/plugins/validate-semantic/index.js
@@ -40,8 +40,14 @@ export default function SemanticValidatorsPlugin({getSystem}) {
         },
         wrapActions: {
           validateSpec: (ori, system) => (...args) => {
-            ori(...args)
-            debAll(system)
+            // verify editor plugin already loaded and function is available (for tests)
+            if (system.specSelectors.specOrigin) {
+              const specOrigin = system.specSelectors.specOrigin()
+              if (specOrigin === "editor") {
+                ori(...args)
+                debAll(system)
+              }
+            }
           }
         }
       },


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
In `SemanticValidatorsPlugin.wrapActions.validateSpec`, it will fire 3 times on a page refresh:
"not-editor"
"local-storage" <-- Also new, I'm passing this text as an optional argument for easier debug
"editor"

Now, `validateSpec` will only subsequently call `debAll` function if "editor" case. Previously, validation was also occurring if "local-storage" case.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
Fixes #1943

Also, YAML reduced to:
```
swagger: '2.0'
info:
  title: test
  version: 0.0.0
paths:
  /pets:
    get:
      parameters:
        - in: query
          name: foo
          type: string
          enum: [apples, oranges]
          default: bananas  # <---- should trigger error
        # - $ref: '#/parameters/bar'
      responses:
        200:
          description: OK
```

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visual testing only


### Screenshots (if appropriate):

![se-1943-fixed](https://user-images.githubusercontent.com/12902658/79171585-4478cf80-7da7-11ea-8a1d-d87c83c2b71c.gif)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
