### PR TITLE
Housekeeping/release it config

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,28 @@ For the older version of swagger-editor, refer to the [*2.x branch*](https://git
 ## Running locally
 
 ##### Prerequisites
-- Node 6.x
-- NPM 3.x
+
+- NPM 6.x
+
+Generally, we recommend following guidelines from [Node.js Releases](https://nodejs.org/en/about/releases/) to only use Active LTS or Maintenance LTS releases.
+
+Current Node.js Active LTS:
+- Node.js 12.x
+- NPM 6.x
+
+Current Node.js Maintenance LTS:
+- Node.js 10.x
+- NPM 6.x
+
+Unsupported Node.js LTS that should still work:
+- Node.js 8.13.0 or greater
+- NPM 6.x
 
 If you have Node.js and npm installed, you can run `npm start` to spin up a static server.
 
 Otherwise, you can open `index.html` directly from your filesystem in your browser.
 
-If you'd like to make code changes to Swagger Editor, you can start up a Webpack hot-reloading dev server via `npm run dev`. 
+If you'd like to make code changes to Swagger Editor, you can start up a Webpack hot-reloading dev server via `npm run dev`.
 
 ##### Browser support
 

--- a/release/.release-it.json
+++ b/release/.release-it.json
@@ -1,13 +1,13 @@
 {
-  "scripts": {
-    "beforeBump": [
+  "hooks": {
+    "before:bump": [
       "./release/check-for-breaking-changes.sh ${latestVersion} ${version}",
       "npm update swagger-client",
       "npm update swagger-ui",
       "npm test"
     ],
-    "beforeStage": ["npm run build"],
-    "afterRelease": "export GIT_TAG=v${version} && echo GIT_TAG=v${version} > release/.version"
+    "after:bump": ["npm run build"],
+    "after:release": "export GIT_TAG=v${version} && echo GIT_TAG=v${version} > release/.version"
   },
   "git": {
     "requireUpstream": false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

release-it config file, migrate "scripts" options to "hooks"

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
Deprecation warning in Release-It v9, and removed in Release-It v13
We are currently using Release-It v12.6.3


### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`npx release-it --dry-run` still passes successfully

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
