### PR TITLE
fix(validation): improve allDefinitions selector to pick up OAS3 schema components

### DIFF
--- a/src/plugins/validate-semantic/selectors.js
+++ b/src/plugins/validate-semantic/selectors.js
@@ -17,6 +17,7 @@ export const isOAS3OperationRequestBody = (state, node) => node.path.length === 
 export const isOAS3OperationCallbackRequestBody = (state, node) => node.path.length === 8 && node.path[7] === "requestBody"
 export const isOAS3RootParameter = (state, node) => node.path[0] === "components" && node.path[1] === "parameters" && node.path.length === 3
 export const isOAS3RootResponse = (state, node) => node.path[0] === "components" && node.path[1] === "responses" && node.path.length === 3
+export const isOAS3RootSchema = (state, node) => node.path[0] === "components" && node.path[1] === "schemas" && node.path.length === 3
 
 export const isSubSchema = (state, node) => (sys) => {
   const path = node.path
@@ -239,7 +240,10 @@ export const allDefinitions = () => (system) => {
   return system.fn.traverseOnce({
     name: "allDefinitions",
     fn: (node) => {
-      if(system.validateSelectors.isDefinition(node)) {
+      if(
+        system.validateSelectors.isDefinition(node)
+         || system.validateSelectors.isOAS3RootSchema(node)
+       ) {
         return node
       }
     },

--- a/test/unit/plugins/selectors.js
+++ b/test/unit/plugins/selectors.js
@@ -44,242 +44,42 @@ function getSystem(spec) {
 describe("validation plugin - selectors", function() {
   this.timeout(10 * 1000)
 
-  it("allSchemas should pick up parameter schemas", () => {
-    const spec = {
-      paths: {
-        test: {
-          parameters: [{
-            name: "common"
-          }],
-          get: {
-            parameters: [{
-              name: "tags"
-            }]
-          }
-        }
-      }
-    }
-
-    return getSystem(spec)
-      .then(system => system.validateSelectors.allSchemas())
-      .then(nodes => {
-        expect(nodes.length).toEqual(2)
-        expect(nodes[0].path).toEqual(["paths","test","parameters","0"])
-        expect(nodes[1].path).toEqual(["paths","test","get","parameters","0"])
-      })
-  })
-
-  it("allSchemas should pick up response schemas", () => {
-    const spec = {
-      paths: {
-        test: {
-          get: {
-            responses: {
-              "200": {
-                schema: {
-                  type: "string"
-                }
+  describe("allSchemas", function() {
+    describe("OpenAPI 2.0", function() {
+      it("should pick up parameter schemas", () => {
+        const spec = {
+          paths: {
+            test: {
+              parameters: [{
+                name: "common"
+              }],
+              get: {
+                parameters: [{
+                  name: "tags"
+                }]
               }
             }
           }
         }
-      }
-    }
 
-    return getSystem(spec)
-      .then(system => system.validateSelectors.allSchemas())
-      .then(nodes => {
-        expect(nodes.length).toEqual(1)
-        expect(nodes[0].path.join(".")).toEqual("paths.test.get.responses.200.schema")
+        return getSystem(spec)
+          .then(system => system.validateSelectors.allSchemas())
+          .then(nodes => {
+            expect(nodes.length).toEqual(2)
+            expect(nodes[0].path).toEqual(["paths","test","parameters","0"])
+            expect(nodes[1].path).toEqual(["paths","test","get","parameters","0"])
+          })
       })
-  })
 
-  it("allSchemas should pick up definitions", () => {
-    const spec = {
-      definitions: {
-        fooModel: {
-          type: "object",
-          properties: {
-          }
-        }
-      }
-    }
-
-    return getSystem(spec)
-      .then(system => system.validateSelectors.allSchemas())
-      .then(nodes => {
-        expect(nodes.length).toEqual(1)
-        expect(nodes[0].key).toEqual("fooModel")
-      })
-  })
-
-  it("allSchemas should pick up headers", () => {
-    const spec = {
-      paths: {
-        test: {
-          get: {
-            responses: {
-              "200": {
-                headers: {
-                  foo: {
-                    "type": "integer"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-
-    return getSystem(spec)
-      .then(system => system.validateSelectors.allSchemas())
-      .then(nodes => {
-        expect(nodes.length).toEqual(1)
-        expect(nodes[0].path.join(".")).toEqual("paths.test.get.responses.200.headers.foo")
-      })
-  })
-
-  it("allSchemas should pick up subschemas in properties", () => {
-    const spec = {
-      definitions: {
-        fooModel: {
-          type: "object",
-          properties: {
-            foo: {
-              type: "string"
-            }
-          }
-        }
-      }
-    }
-
-    return getSystem(spec)
-      .then(system => system.validateSelectors.allSchemas())
-      .then(nodes => {
-        expect(nodes.length).toEqual(2)
-        expect(nodes[0].key).toEqual("fooModel")
-        expect(nodes[1].key).toEqual("foo")
-      })
-  })
-
-  it("allSchemas should pick up subschemas in additionalProperties - simple", () => {
-    const spec = {
-      definitions: {
-        fooModel: {
-          type: "object",
-          additionalProperties: {
-            type: "string"
-          }
-        }
-      }
-    }
-
-    return getSystem(spec)
-      .then(system => system.validateSelectors.allSchemas())
-      .then(nodes => {
-        expect(nodes.length).toEqual(2)
-        expect(nodes[0].key).toEqual("fooModel")
-        expect(nodes[1].key).toEqual("additionalProperties")
-      })
-  })
-
-  it("allSchemas should pick up subschemas in additionalProperties - complex", () => {
-    const spec = {
-      definitions: {
-        fooModel: {
-          type: "object",
-          additionalProperties: {
-            type: "object",
-            properties: {
-              foo: {
-                type: "string"
-              }
-            }
-          }
-        }
-      }
-    }
-
-    return getSystem(spec)
-      .then(system => system.validateSelectors.allSchemas())
-      .then(nodes => {
-        expect(nodes.length).toEqual(3)
-        expect(nodes[0].key).toEqual("fooModel")
-        expect(nodes[1].key).toEqual("additionalProperties")
-        expect(nodes[2].key).toEqual("foo")
-      })
-  })
-
-  it("allSchemas should pick up subschemas in array", () => {
-    const spec = {
-      definitions: {
-        fooModel: {
-          type: "array",
-          items: {
-            type: "string"
-          }
-        }
-      }
-    }
-
-    return getSystem(spec)
-      .then(system => system.validateSelectors.allSchemas())
-      .then(nodes => {
-        expect(nodes.length).toEqual(2)
-        expect(nodes[0].key).toEqual("fooModel")
-        expect(nodes[1].key).toEqual("items")
-      })
-  })
-
-  it("allSchemas should pick up subschemas in array of objects", () => {
-    const spec = {
-      definitions: {
-        fooModel: {
-          type: "array",
-          items: {
-            type: "object",
-            properties: {
-              foo: {
-                type: "string"
-              }
-            }
-          }
-        }
-      }
-    }
-
-    return getSystem(spec)
-      .then(system => system.validateSelectors.allSchemas())
-      .then(nodes => {
-        expect(nodes.length).toEqual(3)
-        expect(nodes[0].key).toEqual("fooModel")
-        expect(nodes[1].key).toEqual("items")
-        expect(nodes[2].key).toEqual("foo")
-      })
-  })
-  it("allSchemas should pick up OAS3 request and response schemas", () => {
-    const spec = {
-      "openapi": "3.0.0",
-      "paths": {
-        "/ping": {
-          "post": {
-            "requestBody": {
-              "content": {
-                "application/myRequestMediaType": {
-                  "schema": {
-                    "type": "array"
-                  }
-                }
-              }
-            },
-            "responses": {
-              "200": {
-                "description": "OK",
-                "content": {
-                  "application/myResponseMediaType": {
-                    "schema": {
-                      "type": "string"
+      it("should pick up response schemas", () => {
+        const spec = {
+          paths: {
+            test: {
+              get: {
+                responses: {
+                  "200": {
+                    schema: {
+                      type: "string"
                     }
                   }
                 }
@@ -287,19 +87,443 @@ describe("validation plugin - selectors", function() {
             }
           }
         }
-      }
-    }
 
-    return getSystem(spec)
-      .then(system => system.validateSelectors.allSchemas())
-      .then(nodes => {
-        expect(nodes.length).toEqual(2)
-        expect(nodes[0].node).toNotBe(nodes[1].node)
-        expect(nodes[0].key).toEqual("schema")
-        expect(nodes[0].parent.key).toEqual("application/myRequestMediaType")
-        expect(nodes[1].key).toEqual("schema")
-        expect(nodes[1].parent.key).toEqual("application/myResponseMediaType")
+        return getSystem(spec)
+          .then(system => system.validateSelectors.allSchemas())
+          .then(nodes => {
+            expect(nodes.length).toEqual(1)
+            expect(nodes[0].path.join(".")).toEqual("paths.test.get.responses.200.schema")
+          })
       })
+
+      it("should pick up global definitions", () => {
+        const spec = {
+          definitions: {
+            fooModel: {
+              type: "object",
+              properties: {
+              }
+            }
+          }
+        }
+
+        return getSystem(spec)
+          .then(system => system.validateSelectors.allSchemas())
+          .then(nodes => {
+            expect(nodes.length).toEqual(1)
+            expect(nodes[0].key).toEqual("fooModel")
+          })
+      })
+
+      it("should pick up global definitions named 'x-' (i.e. not consider them extensions)", () => {
+        const spec = {
+          definitions: {
+            "x-fooModel": {
+              type: "string"
+            }
+          }
+        }
+
+        return getSystem(spec)
+          .then(system => system.validateSelectors.allSchemas())
+          .then(nodes => {
+            expect(nodes.length).toEqual(1)
+            expect(nodes[0].key).toEqual("x-fooModel")
+          })
+      })
+
+      it("should pick up response headers", () => {
+        const spec = {
+          paths: {
+            test: {
+              get: {
+                responses: {
+                  "200": {
+                    headers: {
+                      foo: {
+                        "type": "integer"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        return getSystem(spec)
+          .then(system => system.validateSelectors.allSchemas())
+          .then(nodes => {
+            expect(nodes.length).toEqual(1)
+            expect(nodes[0].path.join(".")).toEqual("paths.test.get.responses.200.headers.foo")
+          })
+      })
+
+      it("should pick up subschemas in properties", () => {
+        const spec = {
+          definitions: {
+            fooModel: {
+              type: "object",
+              properties: {
+                foo: {
+                  type: "string"
+                }
+              }
+            }
+          }
+        }
+
+        return getSystem(spec)
+          .then(system => system.validateSelectors.allSchemas())
+          .then(nodes => {
+            expect(nodes.length).toEqual(2)
+            expect(nodes[0].key).toEqual("fooModel")
+            expect(nodes[1].key).toEqual("foo")
+          })
+      })
+
+      it("should pick up subschemas in additionalProperties - simple", () => {
+        const spec = {
+          definitions: {
+            fooModel: {
+              type: "object",
+              additionalProperties: {
+                type: "string"
+              }
+            }
+          }
+        }
+
+        return getSystem(spec)
+          .then(system => system.validateSelectors.allSchemas())
+          .then(nodes => {
+            expect(nodes.length).toEqual(2)
+            expect(nodes[0].key).toEqual("fooModel")
+            expect(nodes[1].key).toEqual("additionalProperties")
+          })
+      })
+
+      it("should pick up subschemas in additionalProperties - complex", () => {
+        const spec = {
+          definitions: {
+            fooModel: {
+              type: "object",
+              additionalProperties: {
+                type: "object",
+                properties: {
+                  foo: {
+                    type: "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        return getSystem(spec)
+          .then(system => system.validateSelectors.allSchemas())
+          .then(nodes => {
+            expect(nodes.length).toEqual(3)
+            expect(nodes[0].key).toEqual("fooModel")
+            expect(nodes[1].key).toEqual("additionalProperties")
+            expect(nodes[2].key).toEqual("foo")
+          })
+      })
+
+      it("should pick up subschemas in array", () => {
+        const spec = {
+          definitions: {
+            fooModel: {
+              type: "array",
+              items: {
+                type: "string"
+              }
+            }
+          }
+        }
+
+        return getSystem(spec)
+          .then(system => system.validateSelectors.allSchemas())
+          .then(nodes => {
+            expect(nodes.length).toEqual(2)
+            expect(nodes[0].key).toEqual("fooModel")
+            expect(nodes[1].key).toEqual("items")
+          })
+      })
+
+      it("should pick up subschemas in array of objects", () => {
+        const spec = {
+          definitions: {
+            fooModel: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  foo: {
+                    type: "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        return getSystem(spec)
+          .then(system => system.validateSelectors.allSchemas())
+          .then(nodes => {
+            expect(nodes.length).toEqual(3)
+            expect(nodes[0].key).toEqual("fooModel")
+            expect(nodes[1].key).toEqual("items")
+            expect(nodes[2].key).toEqual("foo")
+          })
+      })
+    })
+
+    describe("OpenAPI 3.0", function() {
+      it("should pick up schemas in 'components'", () => {
+        const spec = {
+          openapi: "3.0.0",
+          components: {
+            schemas: {
+              fooModel: {
+                type: "string"
+              }
+            }
+          }
+        }
+
+        return getSystem(spec)
+          .then(system => system.validateSelectors.allSchemas())
+          .then(nodes => {
+            expect(nodes.length).toEqual(1)
+            expect(nodes[0].key).toEqual("fooModel")
+          })
+      })
+
+      it("should pick up schemas named 'x-' (i.e. not consider them extensions)", () => {
+        const spec = {
+          openapi: "3.0.0",
+          components: {
+            schemas: {
+              "x-fooModel": {
+                type: "string"
+              }
+            }
+          }
+        }
+
+        return getSystem(spec)
+          .then(system => system.validateSelectors.allSchemas())
+          .then(nodes => {
+            expect(nodes.length).toEqual(1)
+            expect(nodes[0].key).toEqual("x-fooModel")
+          })
+      })
+
+      it("should pick up request body schemas and response schemas", () => {
+        const spec = {
+          "openapi": "3.0.0",
+          "paths": {
+            "/ping": {
+              "post": {
+                "requestBody": {
+                  "content": {
+                    "application/myRequestMediaType": {
+                      "schema": {
+                        "type": "array"
+                      }
+                    }
+                  }
+                },
+                "responses": {
+                  "200": {
+                    "description": "OK",
+                    "content": {
+                      "application/myResponseMediaType": {
+                        "schema": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        return getSystem(spec)
+          .then(system => system.validateSelectors.allSchemas())
+          .then(nodes => {
+            expect(nodes.length).toEqual(2)
+            expect(nodes[0].node).toNotBe(nodes[1].node)
+            expect(nodes[0].key).toEqual("schema")
+            expect(nodes[0].parent.key).toEqual("application/myRequestMediaType")
+            expect(nodes[1].key).toEqual("schema")
+            expect(nodes[1].parent.key).toEqual("application/myResponseMediaType")
+          })
+      })
+
+      it("should pick up schemas in response components", () => {
+        const spec = {
+          openapi: "3.0.0",
+          components: {
+            responses: {
+              MyResponse: {
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        return getSystem(spec)
+          .then(system => system.validateSelectors.allSchemas())
+          .then(nodes => {
+            expect(nodes.length).toEqual(1)
+            expect(nodes[0].path).toEqual(["components","responses","MyResponse","content","application/json","schema"])
+          })
+      })
+
+      it("should pick up subschemas in properties", () => {
+        const spec = {
+          openapi: "3.0.0",
+          components: {
+            schemas: {
+              fooModel: {
+                type: "object",
+                properties: {
+                  foo: {
+                    type: "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        return getSystem(spec)
+          .then(system => system.validateSelectors.allSchemas())
+          .then(nodes => {
+            expect(nodes.length).toEqual(2)
+            expect(nodes[0].key).toEqual("fooModel")
+            expect(nodes[1].key).toEqual("foo")
+          })
+      })
+
+      it("should pick up subschemas in additionalProperties - simple", () => {
+        const spec = {
+          openapi: "3.0.0",
+          components: {
+            schemas: {
+              fooModel: {
+                type: "object",
+                additionalProperties: {
+                  type: "string"
+                }
+              }
+            }
+          }
+        }
+
+        return getSystem(spec)
+          .then(system => system.validateSelectors.allSchemas())
+          .then(nodes => {
+            expect(nodes.length).toEqual(2)
+            expect(nodes[0].key).toEqual("fooModel")
+            expect(nodes[1].key).toEqual("additionalProperties")
+          })
+      })
+
+      it("should pick up subschemas in additionalProperties - complex", () => {
+        const spec = {
+          openapi: "3.0.0",
+          components: {
+            schemas: {
+              fooModel: {
+                type: "object",
+                additionalProperties: {
+                  type: "object",
+                  properties: {
+                    foo: {
+                      type: "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        return getSystem(spec)
+          .then(system => system.validateSelectors.allSchemas())
+          .then(nodes => {
+            expect(nodes.length).toEqual(3)
+            expect(nodes[0].key).toEqual("fooModel")
+            expect(nodes[1].key).toEqual("additionalProperties")
+            expect(nodes[2].key).toEqual("foo")
+          })
+      })
+
+      it("should pick up subschemas in array", () => {
+        const spec = {
+          openapi: "3.0.0",
+          components: {
+            schemas: {
+              fooModel: {
+                type: "array",
+                items: {
+                  type: "string"
+                }
+              }
+            }
+          }
+        }
+
+        return getSystem(spec)
+          .then(system => system.validateSelectors.allSchemas())
+          .then(nodes => {
+            expect(nodes.length).toEqual(2)
+            expect(nodes[0].key).toEqual("fooModel")
+            expect(nodes[1].key).toEqual("items")
+          })
+      })
+
+      it("should pick up subschemas in array of objects", () => {
+        const spec = {
+          openapi: "3.0.0",
+          components: {
+            schemas: {
+              fooModel: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    foo: {
+                      type: "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        return getSystem(spec)
+          .then(system => system.validateSelectors.allSchemas())
+          .then(nodes => {
+            expect(nodes.length).toEqual(3)
+            expect(nodes[0].key).toEqual("fooModel")
+            expect(nodes[1].key).toEqual("items")
+            expect(nodes[2].key).toEqual("foo")
+          })
+      })
+    })
   })
 
   describe("allResponses", function() {


### PR DESCRIPTION
### Description

Previously, the `allDefinitions` selector only picked up global OAS2 schemas. This PR improves this selector to also pick up global OAS3 schemas in the `components/schemas` section.

**Note to reviewer:** Use the "[Hide whitespace changes](https://help.github.com/assets/images/help/pull_requests/diff-settings-menu.png)" option in the diff viewer to get a better idea of the changes in the tests.

### Motivation and Context

Fix some (not all) of the scenarios mentioned in #2091.

### How Has This Been Tested?
Manually + added unit tests.

### Screenshots (if appropriate):

Before: Validation was NOT triggered for OAS3 schema components.

After: Validation is triggered for OAS3 schema components.

![image](https://user-images.githubusercontent.com/8576823/82948769-1b08b180-9fab-11ea-8b75-f894cd9b8998.png)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
