### PR TITLE
fix: Prevent exception in checkForDefinition if parameter has no 'name'

### DIFF
--- a/src/plugins/validate-semantic/validators/helpers.js
+++ b/src/plugins/validate-semantic/validators/helpers.js
@@ -39,7 +39,7 @@ export function checkForDefinition(paramName, pathItem) {
           .some(param => param.name === paramName && param.in === "path")
 
         const caseMatch = (op.parameters || [])
-        .find(param => !(param.name === paramName) && (param.name.toLowerCase() === paramName.toLowerCase()) && param.in === "path")
+        .find(param => param.name && !(param.name === paramName) && (param.name.toLowerCase() === paramName.toLowerCase()) && param.in === "path")
 
         if(inThisOperation) {
           res.found = true


### PR DESCRIPTION
### Description

During semantic validation, this line
https://github.com/ralphdoe/swagger-editor/blob/master/src/plugins/validate-semantic/validators/helpers.js#L42
tries to convert the parameter name to lower case. But if the parameter has no `name`, then `toLowerCase()` will raise an exception.

This PR attempts to fix the issue.

### Motivation and Context
Fixes #2161.

### How Has This Been Tested?
Manually.

I don't know how to check this in unit tests.

### Screenshots (if appropriate):
n/a

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
