### PR TITLE
Add Runme button to demonstrate the latest version of code

### DIFF
--- a/.runme/config.yaml
+++ b/.runme/config.yaml
@@ -1,0 +1,11 @@
+  
+version: 1.0
+publish: app
+services:
+  app:
+    build:
+      type: dockerfile
+      config: Dockerfile
+    ports:
+    - container: 8080
+      public: 80

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Dependency Status](https://david-dm.org/swagger-api/swagger-editor/status.svg)](https://david-dm.org/swagger-api/swagger-editor)
 [![devDependency Status](https://david-dm.org/swagger-api/swagger-editor/dev-status.svg)](https://david-dm.org/swagger-api/swagger-editor-#info=devDependencies)
 [![Build Status](https://jenkins.swagger.io/view/OSS%20-%20JavaScript/job/oss-swagger-editor-master/badge/icon?subject=jenkins%20build)](https://jenkins.swagger.io/view/OSS%20-%20JavaScript/job/oss-swagger-editor-master/)
+[![Runme](https://svc.runme.io/static/button.svg)](https://runme.io/run?app_id=7fa52594-1877-4655-953f-859a3a19051b)
 
 **🕰️ Looking for the older version of Swagger Editor?** Refer to the [*2.x* branch](https://github.com/swagger-api/swagger-editor/tree/2.x).
 


### PR DESCRIPTION
This PR adds Runme button-label [![Runme](https://svc.runme.io/static/button.svg)](https://runme.io/run?app_id=a1d21e3a-99d9-4087-b5b9-cc5479f336d0) (clickable) to run the project from the latest commit with one click.

### Description
**How it works:**
1. Runme clones the repository and builds a docker image for latest commit;
2. deploys docker image to k8s cluster;
3. creates domain with SSL certificate;
4. shows web application;
5. destroys app instance after 10 minutes.

You can find detailed information how this works [here](https://runme.io/how-it-works). The small demo you can find [here](https://www.youtube.com/channel/UCEysV237wo321JatUTC6Rlg).

### Motivation and Context
**Why do you need this?**
- Runme is perfect solution to demonstrate the current state of code/repository, anybody can just click the button and see the state;
- Runme totally free, we love open source projects and want to support them;
- Runme has only one limit: you can run one commit no more than once every 5 minutes;

### How Has This Been Tested?
No testing required

### Screenshots (if appropriate):
**build**
![build](https://user-images.githubusercontent.com/8326634/83126841-11ce3080-a0e2-11ea-9895-d300aa6333b9.png)
**result**
![result](https://user-images.githubusercontent.com/8326634/83126929-2f02ff00-a0e2-11ea-9092-06bd2cd33a8d.png)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
