### PR TITLE
fix: wait for aliases in bugs/1862

### DIFF
--- a/test/e2e/tests/bugs/1862.js
+++ b/test/e2e/tests/bugs/1862.js
@@ -29,19 +29,19 @@ describe("Editor #1862: codegen download links downgrade HTTPS", () => {
           "code": "a92bc815-f6e3-4a56-839b-fd2e6f379d52",
           "link": "http://generator.swagger.io:80/api/gen/download/a92bc815-f6e3-4a56-839b-fd2e6f379d52"
         }
-      })
+      }).as("httpsServerNodejs")
 
       cy.route({
         url: "http://generator.swagger.io/api/gen/download/*",
         onRequest: () => wasHttpHit = true,
         response: {}
-      })
+      }).as("httpServerGenDownload")
 
       cy.route({
         url: "https://generator.swagger.io/api/gen/download/*",
         onRequest: () => wasHttpsHit = true,
         response: {}
-      })
+      }).as("httpsServerGenDownload")
 
       // Then
       cy.contains("Generate Server")
@@ -50,7 +50,7 @@ describe("Editor #1862: codegen download links downgrade HTTPS", () => {
       cy.contains("nodejs")
         .click()
 
-      cy.wait(100)
+      cy.wait(["@httpsServerNodejs", "@httpsServerGenDownload"])
         .then(() => {
           expect(wasHttpHit).to.equal(false, "has HTTP server been hit")
           expect(wasHttpsHit).to.equal(true, "has HTTPS server been hit")
@@ -70,19 +70,19 @@ describe("Editor #1862: codegen download links downgrade HTTPS", () => {
           "code": "a92bc815-f6e3-4a56-839b-fd2e6f379d52",
           "link": "http://generator.swagger.io:80/api/gen/download/a92bc815-f6e3-4a56-839b-fd2e6f379d52"
         }
-      })
+      }).as("httpsClientJavascript")
 
       cy.route({
         url: "http://generator.swagger.io/api/gen/download/*",
         onRequest: () => wasHttpHit = true,
         response: {}
-      })
+      }).as("httpClientGenDownload")
 
       cy.route({
         url: "https://generator.swagger.io/api/gen/download/*",
         onRequest: () => wasHttpsHit = true,
         response: {}
-      })
+      }).as("httpsClientGenDownload")
 
       // Then
       cy.contains("Generate Client")
@@ -91,7 +91,7 @@ describe("Editor #1862: codegen download links downgrade HTTPS", () => {
       cy.contains("javascript")
         .click()
 
-      cy.wait(100)
+      cy.wait(["@httpsClientJavascript", "@httpsClientGenDownload"])
         .then(() => {
           expect(wasHttpHit).to.equal(false, "has HTTP server been hit")
           expect(wasHttpsHit).to.equal(true, "has HTTPS server been hit")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Per [Cypress Docs](https://docs.cypress.io/guides/references/best-practices.html#Unnecessary-Waiting), replace "Unnecessary Waiting" for arbitrary time periods by using route aliases.

e.g. replace `cy.wait(100)` with `cy.wait(["@aliasname1", "@aliasname2"])`

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Test bugs/1862 frequently fails on Jenkins CI


### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Updated test continues to pass on local (Mac, Node v13)

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
