### PR TITLE
swagger2ConverterUrl is now used in the Edit menu for the actual conv…

### DIFF
--- a/src/standalone/topbar-menu-edit-convert/components/convert-modal.jsx
+++ b/src/standalone/topbar-menu-edit-convert/components/convert-modal.jsx
@@ -9,11 +9,11 @@ export default class ConvertModal extends Component {
       status: "new"
     }
   }
-  convertDefinition = async () => {
+  convertDefinition = async (converterUrl) => {
     this.setState({ status: "converting" })
 
     try {
-      const conversionResult = await this.performConversion()
+      const conversionResult = await this.performConversion(converterUrl)
       this.setState({
         status: "success",
       })
@@ -26,8 +26,8 @@ export default class ConvertModal extends Component {
     }
   }
 
-  performConversion = async () => {
-    const res = await fetch("//converter.swagger.io/api/convert", {
+  performConversion = async (converterUrl) => {
+    const res = await fetch(converterUrl, {
       method: "POST",
       headers: {
         "Content-Type": "application/yaml",
@@ -51,7 +51,7 @@ export default class ConvertModal extends Component {
     if(this.state.status === "new") {
       return <ConvertModalStepNew
         onClose={onClose}
-        onContinue={() => this.convertDefinition()}
+        onContinue={() => this.convertDefinition(converterUrl)}
         getComponent={getComponent}
         converterUrl={converterUrl}
         />
@@ -98,7 +98,7 @@ const ConvertModalStepNew = ({ getComponent, onClose, onContinue, converterUrl }
     <div className="container modal-message">
       <h2>Convert to OpenAPI 3</h2>
       <p>
-        This feature uses the Swagger Converter API to convert your Swagger 2.0 
+        This feature uses the Swagger Converter API to convert your Swagger 2.0
         definition to OpenAPI 3.
         </p>
       <p>


### PR DESCRIPTION
…ersion.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Support for swagger2ConverterUrl configuration was already available but not used in in the GUI.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? --> 
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
Integrate the swagger2ConverterUrl configuration with the web experience, so that the information displayed when selecting the convert to OpenAPI 3.0 option becomes actually valid.


### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on macOS Catalina via `npm run dev` and a swaggerapi/swagger-converter Docker container. Both logs and the Chrome Developer Tools were used to verify the endpoing used.


### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
