### PR TITLE
fix: remove use of alias in /src paths

### DIFF
--- a/src/plugins/editor/components/editor.jsx
+++ b/src/plugins/editor/components/editor.jsx
@@ -6,7 +6,7 @@ import { placeMarkerDecorations } from "../editor-helpers/marker-placer"
 import Im, { fromJS } from "immutable"
 import ImPropTypes from "react-immutable-proptypes"
 
-import win from "src/window"
+import win from "../../../window"
 
 import isUndefined from "lodash/isUndefined"
 import omit from "lodash/omit"

--- a/src/plugins/json-schema-validator/validator.worker.js
+++ b/src/plugins/json-schema-validator/validator.worker.js
@@ -1,4 +1,4 @@
-import "src/polyfills"
+import "../../polyfills"
 import registerPromiseWorker from "promise-worker/register"
 import Validator from "./validator"
 

--- a/src/plugins/validate-semantic/validators/form-data.js
+++ b/src/plugins/validate-semantic/validators/form-data.js
@@ -1,5 +1,5 @@
 import { SOURCE } from "../actions"
-import { getRootNode } from "src/plugins/validate-semantic/helpers"
+import { getRootNode } from "../helpers"
 const operationKeys = ["get", "post", "put", "delete", "options", "head", "patch", "trace"]
 
 export const validateParameterFormDataCaseTypo = () => system => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

`/src` file changes to use relative paths.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Preparation for `babel.config` changes.
The use of alias in swagger-editor is very limited, so limited convenience of using an alias.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

all existing tests pass
`npm build` ok.

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
