### PR TITLE
fix: remove use of polyfills

### DIFF
--- a/src/plugins/json-schema-validator/validator.worker.js
+++ b/src/plugins/json-schema-validator/validator.worker.js
@@ -1,4 +1,3 @@
-import "../../polyfills"
 import registerPromiseWorker from "promise-worker/register"
 import Validator from "./validator"
 

--- a/webpack/bundle.babel.js
+++ b/webpack/bundle.babel.js
@@ -17,7 +17,6 @@ const result = configBuilder(
     entry: {
       "swagger-editor-bundle": [
         "./src/styles/main.less",
-        "./src/polyfills.js",
         "./src/index.js",
       ],
     },

--- a/webpack/core.babel.js
+++ b/webpack/core.babel.js
@@ -15,7 +15,7 @@ const result = configBuilder(
   },
   {
     entry: {
-      "swagger-editor": ["./src/polyfills.js", "./src/index.js"],
+      "swagger-editor": ["./src/index.js"],
     },
 
     output: {

--- a/webpack/dev.babel.js
+++ b/webpack/dev.babel.js
@@ -20,11 +20,9 @@ const devConfig = configBuilder(
     mode: "development",
     entry: {
       "swagger-editor-bundle": [
-        "./src/polyfills.js", // TODO: remove?
         "./src/index.js",
       ],
       "swagger-editor-standalone-preset": [
-        "./src/polyfills", // TODO: remove?
         "./src/standalone/index.js",
       ],
       "swagger-editor": "./src/styles/main.less",

--- a/webpack/test_deps_size.babel.js
+++ b/webpack/test_deps_size.babel.js
@@ -2,6 +2,7 @@
  * @prettier
  */
 
+import path from "path"
 import configBuilder from "./_config-builder"
 
 const result = configBuilder(
@@ -17,7 +18,6 @@ const result = configBuilder(
     entry: {
       "swagger-editor-bundle": [
         "./src/styles/main.less",
-        "./src/polyfills.js",
         "./src/index.js",
       ],
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->



### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Legacy polyfills appear for use in unsupported browser versions.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

existing unit tests - ok
`npm run build` - ok
local browser (chrome, firefox, safari) - ok


### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
