### PR TITLE
fix(validation): use try/catch for pathFromPtr

### DIFF
--- a/src/plugins/validate-semantic/validators/2and3/refs.js
+++ b/src/plugins/validate-semantic/validators/2and3/refs.js
@@ -90,14 +90,18 @@ export const validate2And3RefPointersExist = () => (system) => {
       const value = node.node
       if(typeof value === "string" && value[0] === "#") {
         // if pointer starts with "#", it is a local ref
-        const path = pathFromPtr(qs.unescape(value))
-
-        if(json.getIn(path) === undefined) {
-          errors.push({
-            path: [...node.path.slice(0, -1), "$ref"],
-            message: "$refs must reference a valid location in the document",
-            level: "error"
-          })
+        let path
+        try {
+          path = pathFromPtr(qs.unescape(value))
+          if(json.getIn(path) === undefined) {
+            errors.push({
+              path: [...node.path.slice(0, -1), "$ref"],
+              message: "$refs must reference a valid location in the document",
+              level: "error"
+            })
+          }
+        } catch (e) {
+          // pathFromPtr from json-refs lib will throw new Error
         }
       }
     })


### PR DESCRIPTION
ref #2217

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

wrap the `pathFromPtr` call in a try/catch 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

fixes #2217 

details: `pathFromPtr` from `json-refs` lib will throw new Error, instead of a resolved error message


### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

* existing mocha tests continue to pass
* inbound migration to Jest-based tests will now pass.

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
