### PR TITLE
Fixes #2222

### DIFF
--- a/src/standalone/topbar-insert/forms/components/InsertForm.jsx
+++ b/src/standalone/topbar-insert/forms/components/InsertForm.jsx
@@ -6,9 +6,8 @@ import { checkForEmptyValue } from "../helpers/validation-helpers"
 const InsertForm = ({ formData, getComponent }) => {
   const InsertFormInput = getComponent("InsertFormInput")
   const formRows = []
-  let i = 0
   
-  formData.forEach((v) => {
+  formData.forEach((v, i) => {
     if (OrderedMap.isOrderedMap(v) || Map.isMap(v)) {
       // The form field has a prerequisite field that has been filled out.
       const dependsOnNonEmpty = v.has("dependsOn") && (!checkForEmptyValue(formData.getIn(v.get("dependsOn"))) || v.get("dependsOn") === "formData")
@@ -19,14 +18,13 @@ const InsertForm = ({ formData, getComponent }) => {
         const dependsOnValue = formData.getIn(v.get("dependsOn"))
         const updateOptions = v.get("updateOptions")
 
-        formRows.push(<InsertFormInput formData={v.set("options", updateOptions(dependsOnValue, formData))} index={i} getComponent={getComponent} />)
+        formRows.push(<InsertFormInput formData={v.set("options", updateOptions(dependsOnValue, formData))} index={i} getComponent={getComponent} key={i} />)
       } else if (!v.has("dependsOn") || (!(v.has("updateOptions") && v.has("options")) && dependsOnNonEmpty )) {
         // There is no prerequisite or the prerequisite has been filled out and there is no 
         // additional action to take, so simply show the form field.
-        formRows.push(<InsertFormInput formData={v} index={i} getComponent={getComponent}/>)
+        formRows.push(<InsertFormInput formData={v} index={i} getComponent={getComponent} key={i} />)
       } 
     }
-    i+=1
   })
 
   return <div> {formRows} </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Added `key` prop to each node that is added to the array, replaced the manual index tracker with the index that comes with Array.prototype.forEach().

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
React throwing error for missing key prop in array
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
Fixes #2222 
<!--- automatically closed when this PR is merged. -->



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
Error was only being thrown during Jest tests, tests no longer throw the error.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
