### PR TITLE
Update docker-run.sh

### DIFF
--- a/docker-run.sh
+++ b/docker-run.sh
@@ -18,7 +18,7 @@ if [[ -f "$SWAGGER_FILE" ]]; then
   sed -i "s|SwaggerEditorBundle({|SwaggerEditorBundle({\n      url: '$REL_PATH',|g" $INDEX_FILE
 
   if [[ -z "$SWAGGER_ROOT" ]]; then
-    SWAGGER_ROOT="$(dirname $SWAGGER_JSON)"
+    SWAGGER_ROOT="$(dirname $SWAGGER_FILE)"
   fi
 
   if [[ "$BASE_URL" != "/" ]]


### PR DESCRIPTION
### Description

Root problem: 
If the environment variable `SWAGGER_FILE`  is present and `SWAGGER_ROOT` is not, then the docker container exit with the message:
```
BusyBox v1.31.1 () multi-call binary.

Usage: dirname FILENAME

Strip non-directory suffix from FILENAME
```

### Motivation and Context
Line number 21 using `SWAGGER_JSON` variable instead of `SWAGGER_FILE`. It looks like it is a copy-paste from the swagger-ui project.

### How Has This Been Tested?
I tested this locally.

## Checklist
### My PR contains... 
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.

I didn't found tests for the Docker image.