### PR TITLE
fix(webpack): assets should not be treaded as esModule

### DIFF
--- a/webpack/_config-builder.js
+++ b/webpack/_config-builder.js
@@ -33,7 +33,16 @@ const baseRules = [
     },
   },
   { test: /\.(txt|yaml)$/, loader: "raw-loader" },
-  { test: /\.(png|jpg|jpeg|gif|svg)$/, loader: "url-loader" },
+  {
+    test: /\.(png|jpg|jpeg|gif|svg)$/, use: [
+      {
+        loader: "url-loader",
+        options: {
+          esModule: false,
+        },
+      },
+    ],
+  },
   {
     test: /\.(woff|woff2)$/,
     loader: "url-loader?",
@@ -103,7 +112,7 @@ export default function buildConfig(
             loader: "postcss-loader",
             options: {
               sourceMap: true,
-              plugins: loader => [
+              plugins: () => [
                 require("cssnano")(),
                 require("autoprefixer")(),
               ],


### PR DESCRIPTION
* also fix linting (as required by husky)

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Alongside url-loader@4 dependency bump in PR https://github.com/swagger-api/swagger-editor/pull/2343/, edit the baseRules set to treat /\.(png|jpg|jpeg|gif|svg)$/ as no esModule.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

url-loader@3 changed the esModule default from false to true.
https://github.com/webpack-contrib/url-loader/releases/tag/v3.0.0

also fixed in swagger-ui: https://github.com/swagger-api/swagger-ui/pull/6861

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

browser

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [x] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
