### PR TITLE
fix(validation): Gracefully handle null schemas in some validators

### DIFF
--- a/src/plugins/validate-semantic/validators/2and3/schemas.js
+++ b/src/plugins/validate-semantic/validators/2and3/schemas.js
@@ -30,8 +30,8 @@ export const validate2And3TypesInDefaultValuesMatchesWithEnum = () => (system) =
     .allSchemas()
     .then(nodes => {
       return nodes.reduce((acc, node) => {
-        const schemaObj = node.node
-        const { type } = schemaObj || {}
+        const schemaObj = node.node || {}
+        const { type } = schemaObj
         const isNullable = !!schemaObj.nullable
         const enumeration = schemaObj.enum
         if (enumeration !== null && typeof enumeration !== "undefined") {
@@ -98,7 +98,7 @@ export const validate2And3MinAndMax = () => (system) => {
     .allSchemas()
     .then(nodes => {
       return nodes.reduce((acc, node) => {
-        const schemaObj = node.node
+        const schemaObj = node.node || {}
         const {minimum, maximum, minLength, maxLength, minProperties, maxProperties, minItems, maxItems} = schemaObj
         if(typeof minimum === "number" && typeof maximum === "number" && (minimum > maximum)) {
           acc.push({


### PR DESCRIPTION
This PR fixes an issue in semantic schema validators where the following (invalid) definition results in TypeError exceptions in the browser console.

```yaml
openapi: 3.0.0
info:
  title: test
  version: 1.0.0
paths: {}

components:
  schemas:
    test:
      type: object
      additionalProperties:   # note the missing subschema

```

### Motivation and Context
Improve validators to gracefully handle missing/null schemas.

### How Has This Been Tested?
Tested manually to verify that the provided definition no longer causes console errors after this fix.

### Screenshots (if appropriate):

![Exceptions in browser console before the fix](https://user-images.githubusercontent.com/8576823/122293470-b4c93680-ceff-11eb-9e5e-d7df7c3ba9b5.png)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
