### PR TITLE
fix(validation): OAS3 properties if readOnly, writeOnly both true

### DIFF
--- a/src/plugins/validate-semantic/index.js
+++ b/src/plugins/validate-semantic/index.js
@@ -14,6 +14,7 @@ import * as operationsOAS3ValidateActions from "./validators/oas3/operations"
 import * as parametersOAS3ValidateActions from "./validators/oas3/parameters"
 import * as componentsOAS3ValidateActions from "./validators/oas3/components"
 import * as refsOAS3ValidateActions from "./validators/oas3/refs"
+import * as schemasOAS3ValidateActions from "./validators/oas3/schemas"
 import * as refs2and3ValidateActions from "./validators/2and3/refs"
 import * as parameters2and3ValidateActions from "./validators/2and3/parameters"
 import * as paths2and3ValidateActions from "./validators/2and3/paths"
@@ -69,6 +70,7 @@ export default function SemanticValidatorsPlugin({getSystem}) {
           ...parametersOAS3ValidateActions,
           ...componentsOAS3ValidateActions,
           ...refsOAS3ValidateActions,
+          ...schemasOAS3ValidateActions,
           ...parameters2and3ValidateActions,
           ...paths2and3ValidateActions,
           ...schemas2and3ValidateActions,

--- a/src/plugins/validate-semantic/validators/oas3/schemas.js
+++ b/src/plugins/validate-semantic/validators/oas3/schemas.js
@@ -1,0 +1,27 @@
+export const validateOAS3SchemaPropertiesReadOnlyWriteNotBothTrue = () => (system) => {
+  return system.validateSelectors
+    .allSchemas()
+    .then(nodes => {
+      return nodes.reduce((acc, node) => {
+        const schemaObj = node.node
+        const { properties } = schemaObj
+        if (properties) {
+          for (const [key, value] of Object.entries(properties)) {
+            if (
+              value.readOnly 
+              && typeof value.readOnly === "boolean"
+              && value.writeOnly
+              && typeof value.writeOnly === "boolean"
+              ) {
+              acc.push({
+                message: "A property MUST NOT be marked as both 'readOnly' and 'writeOnly' being 'true'",
+                path: [...node.path, "properties", key],
+                level: "error",
+              })
+            }
+          }
+        }
+        return acc
+      }, [])
+    })
+}

--- a/test/unit/plugins/validate-semantic/oas3/schemas.js
+++ b/test/unit/plugins/validate-semantic/oas3/schemas.js
@@ -1,0 +1,591 @@
+import validateHelper, { expectNoErrors } from '../validate-helper.js';
+
+describe('validation plugin - semantic - oas3 schemas', () => {
+  describe('schema properties that contain both readOnly and writeOnly', () => {
+    it('should return an error if both readOnly/writeOnly exist and are both values are true', () => {
+      const spec = {
+        'openapi': '3.0.0',
+        'servers': [
+          {
+            'description': '',
+            'url': ''
+          }
+        ],
+        'info': {
+          'version': '1.0.0',
+          'title': 'Test Schema Properties'
+        },
+        'paths': {
+          '/': {
+            'post': {
+              'responses': {
+                '200': {
+                  'description': 'response ok'
+                }
+              },
+              'requestBody': {
+                'content': {
+                  'application/json': {
+                    'schema': {
+                      '$ref': '#/components/schemas/PropertyToTest'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        'components': {
+          'schemas': {
+            'PropertyToTest': {
+              'type': 'object',
+              'required': [
+                'id',
+                'fieldname',
+                'fieldDate'
+              ],
+              'properties': {
+                'id': {
+                  'type': 'string',
+                  'format': 'uuid',
+                  'readOnly': true,
+                  'writeOnly': true
+                },
+                'fieldname': {
+                  'type': 'string'
+                },
+                'fieldDate': {
+                  'type': 'string',
+                  'format': 'date-time'
+                }
+              }
+            }
+          }
+        }
+      };
+      return validateHelper(spec)
+        .then(system => {
+          const allErrors = system.errSelectors.allErrors().toJS();
+          expect(allErrors.length).toEqual(1);
+          const firstError = allErrors[0];
+          expect(firstError.message).toEqual('A property MUST NOT be marked as both \'readOnly\' and \'writeOnly\' being \'true\'');
+          expect(firstError.path).toEqual(['components', 'schemas', 'PropertyToTest', 'properties', 'id']);
+        });
+    });
+
+    it('should not return an error if oneOf readOnly/writeOnly value is a string', () => {
+      // Note: this spec should return parser error that 'writeOnly' should be a boolean, 
+      // but should not return a validation-plugin error. e.g true != 'true'
+      const spec = {
+        'openapi': '3.0.0',
+        'servers': [
+          {
+            'description': '',
+            'url': ''
+          }
+        ],
+        'info': {
+          'version': '1.0.0',
+          'title': 'Test Schema Properties'
+        },
+        'paths': {
+          '/': {
+            'post': {
+              'responses': {
+                '200': {
+                  'description': 'response ok'
+                }
+              },
+              'requestBody': {
+                'content': {
+                  'application/json': {
+                    'schema': {
+                      '$ref': '#/components/schemas/PropertyToTest'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        'components': {
+          'schemas': {
+            'PropertyToTest': {
+              'type': 'object',
+              'required': [
+                'id',
+                'fieldname',
+                'fieldDate'
+              ],
+              'properties': {
+                'id': {
+                  'type': 'string',
+                  'format': 'uuid',
+                  'readOnly': true,
+                  'writeOnly': 'true' // <-- not boolean
+                },
+                'fieldname': {
+                  'type': 'string'
+                },
+                'fieldDate': {
+                  'type': 'string',
+                  'format': 'date-time'
+                }
+              }
+            }
+          }
+        }
+      };
+      return expectNoErrors(spec);
+    });
+
+    it('should not return an error if both readOnly/writeOnly values are false', () => {
+      const spec = {
+        'openapi': '3.0.0',
+        'servers': [
+          {
+            'description': '',
+            'url': ''
+          }
+        ],
+        'info': {
+          'version': '1.0.0',
+          'title': 'Test Schema Properties'
+        },
+        'paths': {
+          '/': {
+            'post': {
+              'responses': {
+                '200': {
+                  'description': 'response ok'
+                }
+              },
+              'requestBody': {
+                'content': {
+                  'application/json': {
+                    'schema': {
+                      '$ref': '#/components/schemas/PropertyToTest'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        'components': {
+          'schemas': {
+            'PropertyToTest': {
+              'type': 'object',
+              'required': [
+                'id',
+                'fieldname',
+                'fieldDate'
+              ],
+              'properties': {
+                'id': {
+                  'type': 'string',
+                  'format': 'uuid',
+                  'readOnly': false,
+                  'writeOnly': false
+                },
+                'fieldname': {
+                  'type': 'string'
+                },
+                'fieldDate': {
+                  'type': 'string',
+                  'format': 'date-time'
+                }
+              }
+            }
+          }
+        }
+      };
+      return expectNoErrors(spec);
+    });
+    
+    it('should not return an error if readOnly value is true and writeOnly value is false', () => {
+      const spec = {
+        'openapi': '3.0.0',
+        'servers': [
+          {
+            'description': '',
+            'url': ''
+          }
+        ],
+        'info': {
+          'version': '1.0.0',
+          'title': 'Test Schema Properties'
+        },
+        'paths': {
+          '/': {
+            'post': {
+              'responses': {
+                '200': {
+                  'description': 'response ok'
+                }
+              },
+              'requestBody': {
+                'content': {
+                  'application/json': {
+                    'schema': {
+                      '$ref': '#/components/schemas/PropertyToTest'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        'components': {
+          'schemas': {
+            'PropertyToTest': {
+              'type': 'object',
+              'required': [
+                'id',
+                'fieldname',
+                'fieldDate'
+              ],
+              'properties': {
+                'id': {
+                  'type': 'string',
+                  'format': 'uuid',
+                  'readOnly': true,
+                  'writeOnly': false
+                },
+                'fieldname': {
+                  'type': 'string'
+                },
+                'fieldDate': {
+                  'type': 'string',
+                  'format': 'date-time'
+                }
+              }
+            }
+          }
+        }
+      };
+      return expectNoErrors(spec);
+    });
+
+    it('should not return an error if readOnly value is false and writeOnly value is true', () => {
+      const spec = {
+        'openapi': '3.0.0',
+        'servers': [
+          {
+            'description': '',
+            'url': ''
+          }
+        ],
+        'info': {
+          'version': '1.0.0',
+          'title': 'Test Schema Properties'
+        },
+        'paths': {
+          '/': {
+            'post': {
+              'responses': {
+                '200': {
+                  'description': 'response ok'
+                }
+              },
+              'requestBody': {
+                'content': {
+                  'application/json': {
+                    'schema': {
+                      '$ref': '#/components/schemas/PropertyToTest'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        'components': {
+          'schemas': {
+            'PropertyToTest': {
+              'type': 'object',
+              'required': [
+                'id',
+                'fieldname',
+                'fieldDate'
+              ],
+              'properties': {
+                'id': {
+                  'type': 'string',
+                  'format': 'uuid',
+                  'readOnly': false,
+                  'writeOnly': true
+                },
+                'fieldname': {
+                  'type': 'string'
+                },
+                'fieldDate': {
+                  'type': 'string',
+                  'format': 'date-time'
+                }
+              }
+            }
+          }
+        }
+      };
+      return expectNoErrors(spec);
+    });
+  });
+
+  describe('schema properties that contain only oneOf readOnly/writeOnly', () => {
+    it('should not return an error if only readOnly exists and value is true', () => {
+      const spec = {
+        'openapi': '3.0.0',
+        'servers': [
+          {
+            'description': '',
+            'url': ''
+          }
+        ],
+        'info': {
+          'version': '1.0.0',
+          'title': 'Test Schema Properties'
+        },
+        'paths': {
+          '/': {
+            'post': {
+              'responses': {
+                '200': {
+                  'description': 'response ok'
+                }
+              },
+              'requestBody': {
+                'content': {
+                  'application/json': {
+                    'schema': {
+                      '$ref': '#/components/schemas/PropertyToTest'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        'components': {
+          'schemas': {
+            'PropertyToTest': {
+              'type': 'object',
+              'required': [
+                'id',
+                'fieldname',
+                'fieldDate'
+              ],
+              'properties': {
+                'id': {
+                  'type': 'string',
+                  'format': 'uuid',
+                  'readOnly': true,
+                },
+                'fieldname': {
+                  'type': 'string'
+                },
+                'fieldDate': {
+                  'type': 'string',
+                  'format': 'date-time'
+                }
+              }
+            }
+          }
+        }
+      };
+      return expectNoErrors(spec);
+    });
+  
+    it('should not return an error if only readOnly exists and value is false', () => {
+      const spec = {
+        'openapi': '3.0.0',
+        'servers': [
+          {
+            'description': '',
+            'url': ''
+          }
+        ],
+        'info': {
+          'version': '1.0.0',
+          'title': 'Test Schema Properties'
+        },
+        'paths': {
+          '/': {
+            'post': {
+              'responses': {
+                '200': {
+                  'description': 'response ok'
+                }
+              },
+              'requestBody': {
+                'content': {
+                  'application/json': {
+                    'schema': {
+                      '$ref': '#/components/schemas/PropertyToTest'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        'components': {
+          'schemas': {
+            'PropertyToTest': {
+              'type': 'object',
+              'required': [
+                'id',
+                'fieldname',
+                'fieldDate'
+              ],
+              'properties': {
+                'id': {
+                  'type': 'string',
+                  'format': 'uuid',
+                  'readOnly': false,
+                },
+                'fieldname': {
+                  'type': 'string'
+                },
+                'fieldDate': {
+                  'type': 'string',
+                  'format': 'date-time'
+                }
+              }
+            }
+          }
+        }
+      };
+      return expectNoErrors(spec);
+    });
+  
+    it('should not return an error if only writeOnly exists and value is true', () => {
+      const spec = {
+        'openapi': '3.0.0',
+        'servers': [
+          {
+            'description': '',
+            'url': ''
+          }
+        ],
+        'info': {
+          'version': '1.0.0',
+          'title': 'Test Schema Properties'
+        },
+        'paths': {
+          '/': {
+            'post': {
+              'responses': {
+                '200': {
+                  'description': 'response ok'
+                }
+              },
+              'requestBody': {
+                'content': {
+                  'application/json': {
+                    'schema': {
+                      '$ref': '#/components/schemas/PropertyToTest'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        'components': {
+          'schemas': {
+            'PropertyToTest': {
+              'type': 'object',
+              'required': [
+                'id',
+                'fieldname',
+                'fieldDate'
+              ],
+              'properties': {
+                'id': {
+                  'type': 'string',
+                  'format': 'uuid',
+                  'writeOnly': false
+                },
+                'fieldname': {
+                  'type': 'string'
+                },
+                'fieldDate': {
+                  'type': 'string',
+                  'format': 'date-time'
+                }
+              }
+            }
+          }
+        }
+      };
+      return expectNoErrors(spec);
+    });
+  
+    it('should not return an error if only writeOnly exists and value is false', () => {
+      const spec = {
+        'openapi': '3.0.0',
+        'servers': [
+          {
+            'description': '',
+            'url': ''
+          }
+        ],
+        'info': {
+          'version': '1.0.0',
+          'title': 'Test Schema Properties'
+        },
+        'paths': {
+          '/': {
+            'post': {
+              'responses': {
+                '200': {
+                  'description': 'response ok'
+                }
+              },
+              'requestBody': {
+                'content': {
+                  'application/json': {
+                    'schema': {
+                      '$ref': '#/components/schemas/PropertyToTest'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        'components': {
+          'schemas': {
+            'PropertyToTest': {
+              'type': 'object',
+              'required': [
+                'id',
+                'fieldname',
+                'fieldDate'
+              ],
+              'properties': {
+                'id': {
+                  'type': 'string',
+                  'format': 'uuid',
+                  'writeOnly': true
+                },
+                'fieldname': {
+                  'type': 'string'
+                },
+                'fieldDate': {
+                  'type': 'string',
+                  'format': 'date-time'
+                }
+              }
+            }
+          }
+        }
+      };
+      return expectNoErrors(spec);
+    });
+
+  });
+
+
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

* New validation actions for OAS3 schemas. Specifically checks if both `readOnly` and `writeOnly` are present within `schemas.properties` and both set to true.
* New support tests to support OAS3 schemas validation actions


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #2863 

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

New tests as noted above

### Screenshots (if appropriate):



![swagger-editor-pr-2864](https://user-images.githubusercontent.com/12902658/148308757-8d129179-11aa-42a3-84f4-f2323b39b010.png)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
