### PR TITLE
fix: autocompletion regex for OAS3 component names

### DIFF
--- a/src/plugins/editor-autosuggest-oas3-keywords/oas3-objects.js
+++ b/src/plugins/editor-autosuggest-oas3-keywords/oas3-objects.js
@@ -247,7 +247,7 @@ export const SecurityScheme = {
   openIdConnectUrl: String,
 }
 
-const ComponentFixedFieldRegex = "^[a-zA-Z0-9.-_]+$"
+const ComponentFixedFieldRegex = "^[a-zA-Z0-9._-]+$"
 
 export const Components = {
   schemas: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
This PR fixes an incorrect regex that appears in the autocompletion popup under the `components.schemas` node. As explained in #2892:

> The character range `[.-_]` means "any symbol in Unicode table between `.` and `_`" (there are [50 characters](https://unicode-table.com/en/) in this range), whereas `[._-]` means these three characters only.


### Motivation and Context
Fixes #2892.

### How Has This Been Tested?

### Screenshots (if appropriate):

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
