### PR TITLE
fix(jest): use more flexible matcher with `arrayContaining`

### DIFF
--- a/test/unit/plugins/validate-semantic/2and3/refs.js
+++ b/test/unit/plugins/validate-semantic/2and3/refs.js
@@ -454,18 +454,23 @@ describe('validation plugin - semantic - 2and3 refs', () => {
         .then(system => {
           const allSemanticErrors = system.errSelectors.allErrors().toJS()
             .filter(err => err.source !== 'resolver');
-            expect(allSemanticErrors[0]).toEqual(expect.objectContaining({
-              level: 'warning',
-              message: 'Definition was declared but never used in document',
-              path: ['definitions', 'foo bar']
-            }));
-            expect(allSemanticErrors.length).toEqual(2);
-            expect(allSemanticErrors[1]).toEqual(expect.objectContaining({
-              level: 'error',
-              message: '$ref values must be RFC3986-compliant percent-encoded URIs',
-              path: ['paths', '/foo', 'get', 'responses', '200', 'schema', '$ref']
-            }));
-         });
+          expect(allSemanticErrors).toEqual(
+            expect.arrayContaining(
+              [
+                expect.objectContaining({
+                  level: 'warning',
+                  message: 'Definition was declared but never used in document',
+                  path: ['definitions', 'foo bar']
+                }),
+                expect.objectContaining({
+                  level: 'error',
+                  message: '$ref values must be RFC3986-compliant percent-encoded URIs',
+                  path: ['paths', '/foo', 'get', 'responses', '200', 'schema', '$ref']
+                })
+              ]
+            )
+          );
+        });
       }
     );
 
@@ -505,22 +510,27 @@ describe('validation plugin - semantic - 2and3 refs', () => {
         .then(system => {
           const allSemanticErrors = system.errSelectors.allErrors().toJS()
             .filter(err => err.source !== 'resolver');
-            expect(allSemanticErrors.length).toEqual(3);
-            expect(allSemanticErrors[0]).toEqual(expect.objectContaining({
-              level: 'warning',
-              message: 'Definition was declared but never used in document',
-              path: ['components', 'schemas', 'foo bar']
-            }));
-            expect(allSemanticErrors[1]).toEqual(expect.objectContaining({
-              level: 'error',
-              message: '$ref values must be RFC3986-compliant percent-encoded URIs',
-              path: ['paths', '/foo', 'get', 'responses', '200', 'content', 'application/json', 'schema', '$ref']
-            }));
-            expect(allSemanticErrors[2]).toEqual(expect.objectContaining({
-              level: 'error',
-              message: 'Component names can only contain the characters A-Z a-z 0-9 - . _',
-              path: ['components', 'schemas', 'foo bar']
-            }));
+          expect(allSemanticErrors.length).toEqual(3);
+          expect(allSemanticErrors).toEqual(
+            expect.arrayContaining(
+              [
+                expect.objectContaining({
+                  level: 'warning',
+                  message: 'Definition was declared but never used in document',
+                  path: ['components', 'schemas', 'foo bar']
+                }),
+                expect.objectContaining({
+                  level: 'error',
+                  message: '$ref values must be RFC3986-compliant percent-encoded URIs',
+                  path: ['paths', '/foo', 'get', 'responses', '200', 'content', 'application/json', 'schema', '$ref']
+                }),
+                expect.objectContaining({
+                  level: 'error',
+                  message: 'Component names can only contain the characters A-Z a-z 0-9 - . _',
+                  path: ['components', 'schemas', 'foo bar']
+                }),
+              ]
+            ));
         });
       }
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Use `expect.arrayContaining()` to match against a subset of array items. Replaces `expect.objectContaining` check against each element by array position. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Although these two tests have been running on CI for a long time, recently these tests started failing on my local Mac environment. The issue was that the resulting test array elements were not in the same order as expected in the test.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

existing tests now pass again.

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
