### PR TITLE
feat(unprivileged): run unprivileged nginx to support arbitrarily assigned user ID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.23.2-alpine
+FROM nginxinc/nginx-unprivileged:1.23.2-alpine
 
 LABEL maintainer="fehguy"
 
@@ -10,11 +10,6 @@ COPY ./index.html /usr/share/nginx/html/
 COPY ./dist/oauth2-redirect.html /usr/share/nginx/html/
 COPY ./dist/* /usr/share/nginx/html/dist/
 COPY ./docker-run.sh /usr/share/nginx/
-
-
-RUN chmod +x /usr/share/nginx/docker-run.sh && \
-    chmod -R a+rw /usr/share/nginx && \
-    chmod -R a+rw /etc/nginx
 
 EXPOSE 8080
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,10 +1,21 @@
-worker_processes      1;
+worker_processes      auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /tmp/nginx.pid;
 
 events {
   worker_connections  1024;
 }
 
 http {
+  proxy_temp_path /tmp/proxy_temp;
+  client_body_temp_path /tmp/client_temp;
+  fastcgi_temp_path /tmp/fastcgi_temp;
+  uwsgi_temp_path /tmp/uwsgi_temp;
+  scgi_temp_path /tmp/scgi_temp;
+
+  include /etc/nginx/conf.d/*.conf;
+
   include             mime.types;
   default_type        application/octet-stream;
 


### PR DESCRIPTION
Use unprivileged nginx to support arbitrarily assigned user ID to be able to run the image e.g. on Red Hat Openshift

### Description
The dockerfile uses the `nginxinc/nginx-unprivileged` image instead of the standard `nginx` image.
Moreover the `nginx.conf` file was extended for some configuration to locate nginx runtime data in the `/tmp` directory.

This enables the container to run as a non-root user which is an improvement to the container security and enables running the container on distributions such as OpenShift by default.



### Motivation and Context
The change is necessary as the previous version required nginx to run as root to be able to read/write so several default paths.

Fixes #2931 

### How Has This Been Tested?
Dependencies: `npm ci`
Build: `npm build`
Docker Build: `docker build -t swagger-editor-unprivileged .`
Docker Run: `docker run -p 8080:8080 -u 100000 swagger-editor-unprivileged`
Visit in browser: http://localhost:8080

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [X] Improvements (misc. changes to existing features)
- [X] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [X] are not breaking changes.

### Documentation
- [X] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [X] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [X] All new and existing tests passed.
