### PR TITLE
fix(validate-semantic): trigger errors for Header & Parameter in OAS3

### DIFF
--- a/src/plugins/validate-semantic/selectors.js
+++ b/src/plugins/validate-semantic/selectors.js
@@ -18,6 +18,7 @@ export const isOAS3OperationCallbackRequestBody = (state, node) => node.path.len
 export const isOAS3RootParameter = (state, node) => node.path[0] === "components" && node.path[1] === "parameters" && node.path.length === 3
 export const isOAS3RootResponse = (state, node) => node.path[0] === "components" && node.path[1] === "responses" && node.path.length === 3
 export const isOAS3RootSchema = (state, node) => node.path[0] === "components" && node.path[1] === "schemas" && node.path.length === 3
+export const isOAS3RootHeader = (state, node) => node.path[0] === "components" && node.path[1] === "headers" && node.path.length === 3
 
 export const isSubSchema = (state, node) => (sys) => {
   const path = node.path
@@ -127,6 +128,7 @@ export const isHeader = (state, node) => (sys) => {
   }
   return (
     sys.validateSelectors.isRootHeader(node)
+      || sys.validateSelectors.isOAS3RootHeader(node)
       || ( node.path[0] === "paths"
            && node.path[3] === "responses"
            && node.path[5] === "headers"

--- a/test/unit/plugins/validate-semantic/2and3/paths.js
+++ b/test/unit/plugins/validate-semantic/2and3/paths.js
@@ -90,7 +90,7 @@ describe('validation plugin - semantic - 2and3 paths', () => {
     describe('Path parameter definitions need matching paramater declarations', () => {
       describe('OpenAPI 3', () => {
         it(
-          'should not return problems for a valid path-level definiton/declaration pair',
+          'should not return problems for a valid path-level definition/declaration pair',
           () => {
             const spec = {
               openapi: '3.0.0',
@@ -111,23 +111,25 @@ describe('validation plugin - semantic - 2and3 paths', () => {
         );
 
         it(
-          'should not return problems for a valid path-level definiton/declaration pair using a $ref',
+          'should not return problems for a valid path-level definition/declaration pair using a $ref',
           () => {
             const spec = {
               openapi: '3.0.0',
               paths: {
                 '/CoolPath/{id}': {
                   parameters: [
-                    { $ref: '#/parameters/id' }
+                    { $ref: '#/components/parameters/id' }
                   ]
                 }
               },
-              parameters: {
-                id: {
-                  name: 'id',
-                  in: 'path',
-                  description: 'An id',
-                  required: true
+              components: {
+                parameters: {
+                  id: {
+                    name: 'id',
+                    in: 'path',
+                    description: 'An id',
+                    required: true
+                  }
                 }
               }
             };

--- a/test/unit/plugins/validate-semantic/oas3/refs.js
+++ b/test/unit/plugins/validate-semantic/oas3/refs.js
@@ -350,11 +350,11 @@ describe('validation plugin - semantic - oas3 refs', () => {
           .then(system => {
             const allErrors = system.errSelectors.allErrors().toJS();
             const allSemanticErrors = allErrors.filter(err => err.source === 'semantic');
-            
+
             expect(allSemanticErrors.length).toEqual(1);
-            
+
             const firstError = allSemanticErrors[0];
-            
+
             expect(firstError.message).toEqual('requestBody schema $refs must point to a position where a Schema Object can be legally placed');
             expect(firstError.path).toEqual(['paths', '/foo', 'post', 'requestBody', 'content', 'application/json', 'schema', '$ref']);
 
@@ -549,14 +549,16 @@ describe('validation plugin - semantic - oas3 refs', () => {
         return validateHelper(spec)
           .then(system => {
             const allErrors = system.errSelectors.allErrors().toJS();
-            const firstError = allErrors[0];
-            expect(allErrors.length).toEqual(1);
-            expect(firstError.message).toEqual('OAS3 header $refs should point to #/components/headers/... and not #/components/parameters/...');
+            const [firstError, secondError] = allErrors;
+            expect(allErrors.length).toEqual(2);
+            expect(firstError.message).toEqual('OAS3 header $refs should point to Header Object and not #/components/parameters/MyHeader');
             expect(firstError.path).toEqual(['paths', '/foo', 'get','responses','200', 'headers', 'X-MyHeader', '$ref']);
+            expect(secondError.message).toEqual('OAS3 header $refs should point to Header Object and not #/components/parameters/MyHeader');
+            expect(secondError.path).toEqual(['components', 'headers', 'MyHeader', '$ref']);
           });
       }
     );
-    
+
     it(
       'should return no errors when a response header correctly references a local header component',
       () => {
@@ -591,7 +593,7 @@ describe('validation plugin - semantic - oas3 refs', () => {
         return expectNoErrorsOrWarnings(spec);
       }
     );
-    
+
     it('should return no errors for external $refs in response headers', () => {
       const spec = {
         openapi: '3.0.0',
@@ -669,18 +671,18 @@ describe('validation plugin - semantic - oas3 refs', () => {
             const allErrors = system.errSelectors.allErrors().toJS();
             expect(allErrors.length).toEqual(3);
             const firstError = allErrors[0];
-            expect(firstError.message).toEqual('OAS3 parameter $refs should point to #/components/parameters/... and not #/components/headers/...');
+            expect(firstError.message).toEqual('OAS3 parameter $refs should point to Parameter Object and not #/components/headers/foo');
             expect(firstError.path).toEqual(['paths','/foo','parameters', '0', '$ref']);
             const secondError = allErrors[1];
-            expect(secondError.message).toEqual('OAS3 parameter $refs should point to #/components/parameters/... and not #/components/headers/...');
+            expect(secondError.message).toEqual('OAS3 parameter $refs should point to Parameter Object and not #/components/headers/foo');
             expect(secondError.path).toEqual(['paths','/foo','get','parameters', '0', '$ref']);
             const thirdError = allErrors[2];
-            expect(thirdError.message).toEqual('OAS3 parameter $refs should point to #/components/parameters/... and not #/components/headers/...');
+            expect(thirdError.message).toEqual('OAS3 parameter $refs should point to Parameter Object and not #/components/headers/foo');
             expect(thirdError.path).toEqual(['components','parameters', 'myParam', '$ref']);
           });
       }
     );
-    
+
     it(
       'should return no errors when a parameter correctly references a parameter component',
       () => {
@@ -719,7 +721,7 @@ describe('validation plugin - semantic - oas3 refs', () => {
         return expectNoErrorsOrWarnings(spec);
       }
     );
-    
+
     it('should return no errors for external parameter $refs', () => {
       const spec = {
         openapi: '3.0.0',


### PR DESCRIPTION
Errors are now triggered when Reference Object originating
either from Header or Parameter Object points to something
different then Header or Parameter Object.

Refs #3078

### Description

Semantic Validation Errors are now triggered when Reference Object originating
either from Header Object or Parameter Object points to something
different then Header Object or Parameter Object.



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



### Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/193286/173348558-7ced80ed-a633-4c11-97f8-b782101dcff4.png)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
