### PR TITLE
ci changes for editor-next on rancher

### DIFF
--- a/.github/workflows/deploy-rancher.yml
+++ b/.github/workflows/deploy-rancher.yml
@@ -72,4 +72,4 @@ jobs:
           RANCHER_NAMESPACE: 'swagger-oss'
           RANCHER_K8S_OBJECT_TYPE: 'daemonsets'
           RANCHER_URL: ${{ secrets.RANCHER_URL }}
-          RANCHER_K8S_OBJECT_NAME: 'swagger-ide'
+          RANCHER_K8S_OBJECT_NAME: 'swagger-editor-next'


### PR DESCRIPTION
Per OP-16316

deploy-rancher.yml will now accurately reflect the Rancher K8s object name for editor-next

All relevant repository secrets have also been added.