### PR TITLE
ci: update docker tag

### DIFF
--- a/.github/workflows/deploy-rancher.yml
+++ b/.github/workflows/deploy-rancher.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: smartbear/swagger-ide:latest
+          tags: swaggerapi/swagger-editor:next-v5
 
       - name: Deploy Rancher🚢
         run: |


### PR DESCRIPTION
Push builds to the public swagger-editor repo using the `:next-v5` tag