### PR TITLE
docs(ga): add do-not-modify warning to actions within `@next` branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,43 @@
+# Do not modify this file. 
+# Dependabot configuration can only be changed in the default branch
+
 version: 2
 updates:
   - package-ecosystem: npm
-    target-branch: "next"
     directory: "/"
     schedule:
       interval: daily
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    open-pull-requests-limit: 3
+    ignore:
+      # node-fetch must be synced manually
+      - dependency-name: "node-fetch"
+      - dependency-name: "release-it"
+      - dependency-name: "@release-it/conventional-changelog"
+
+  - package-ecosystem: "docker"
+    # Look for a `Dockerfile` in the `root` directory
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  ######################
+  # SwaggerEditor@next #
+  ######################
+
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+    target-branch: "next"
     labels:
       - "swagger-editor@next"
       - "cat: dependencies"

--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -1,8 +1,12 @@
+# Do not modify this file. 
+# Github Actions only recognizes `workflow_run` and `workflow_dispatch`
+# events that are located in the default branch
+
 name: Dependabot Merge Me!
 
 on:
   pull_request_target:
-    branches: [ next ]
+    branches: [ master, next ]
 
 jobs:
   merge-me:

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,3 +1,7 @@
+# Do not modify this file. 
+# Github Actions only recognizes `workflow_run` and `workflow_dispatch`
+# events that are located in the default branch
+
 # inspired by https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
 name: Deploy SwaggerEditor@next to GitHub Pages
 
@@ -6,8 +10,6 @@ on:
     workflows: ["SwaggerEditor@next build", "SwaggerEditor@next nightly build"]
     types:
       - completed
-    branches:
-      - next
 
 jobs:
 
@@ -21,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: next
       - name: 'Download build artifact'
         uses: actions/github-script@v6
         with:

--- a/.github/workflows/deploy-rancher.yml
+++ b/.github/workflows/deploy-rancher.yml
@@ -1,3 +1,7 @@
+# Do not modify this file. 
+# Github Actions only recognizes `workflow_run` and `workflow_dispatch`
+# events that are located in the default branch
+
 # inspired by https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
 name: Deploy SwaggerEditor@next to Rancher🚢
 
@@ -6,8 +10,6 @@ on:
     workflows: ["SwaggerEditor@next build", "SwaggerEditor@next nightly build"]
     types:
       - completed
-    branches:
-      - next
 
 jobs:
 
@@ -21,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: next
       - name: 'Download build artifact'
         uses: actions/github-script@v6
         with:
@@ -56,7 +60,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: smartbear/swagger-ide:latest
+          tags: swaggerapi/swagger-editor:next-v5
 
       - name: Deploy Rancher🚢
         run: |
@@ -72,4 +76,4 @@ jobs:
           RANCHER_NAMESPACE: 'swagger-oss'
           RANCHER_K8S_OBJECT_TYPE: 'daemonsets'
           RANCHER_URL: ${{ secrets.RANCHER_URL }}
-          RANCHER_K8S_OBJECT_NAME: 'swagger-ide'
+          RANCHER_K8S_OBJECT_NAME: 'swagger-editor-next'

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,9 +1,13 @@
+# Do not modify this file. 
+# Github Actions only recognizes `workflow_run` and `workflow_dispatch`
+# events that are located in the default branch
+
 name: SwaggerEditor@next nightly build
 
 on:
   workflow_dispatch:
   schedule:
-    - cron:  '30 21 * * *'
+    - cron:  '30 22 * * *'
 
 jobs:
   nightly-build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,7 @@
+# Do not modify this file. 
+# Github Actions only recognizes `workflow_run` and `workflow_dispatch`
+# events that are located in the default branch
+
 name: Release SwaggerEditor@next
 on:
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ It's bundled with React defined as external. This allows consumer to use his own
 
 **npm**
 
-SwaggerEditor is released as `@swagger-api/swagger-ide` npm package on [GitHub packages registry](https://docs.github.com/en/packages/learn-github-packages/introduction-to-github-packages).
+SwaggerEditor is released as `@swagger-api/swagger-editor` npm package on [GitHub packages registry](https://docs.github.com/en/packages/learn-github-packages/introduction-to-github-packages).
 Package can also be produced manually by running following commands (assuming you're already followed [setting up](#setting-up) steps):
 
 ```sh


### PR DESCRIPTION
* apply github actions code changes from `master` branch to `next` branch
* update github package documentation reference

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

* Add warning documentation warning not to modify github actions workflows that reside in the `next` branch.
* Apply github actions code changes from `master` branch to `next` branch for reference.
* apply one github package documentation reference of `@swagger-api/swagger-ide` change to `@swagger-api/swagger-editor`

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Clarity and reference for future development.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [x] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
