### PR TITLE
feat: separate validationPane for asyncapi parser

### DIFF
--- a/src/plugins/editor-preview-asyncapi/actions.js
+++ b/src/plugins/editor-preview-asyncapi/actions.js
@@ -3,3 +3,12 @@ export {
   getIsOasOrAsyncApi2,
   shouldUpdateDefinitionLanguage,
 } from '../../utils/spec-get-definition-language.js';
+
+export const ASYNCAPI_PARSER_ERROR_MARKERS = 'asyncapi_parser_error_markers';
+
+export const updateAsyncApiParserMarkers = (markers = []) => {
+  return {
+    payload: markers,
+    type: ASYNCAPI_PARSER_ERROR_MARKERS,
+  };
+};

--- a/src/plugins/editor-preview-asyncapi/components/AsyncAPIEditorPreviewPane.jsx
+++ b/src/plugins/editor-preview-asyncapi/components/AsyncAPIEditorPreviewPane.jsx
@@ -7,6 +7,7 @@ import * as avroSchemaParser from '@asyncapi/avro-schema-parser';
 
 import * as ramlSchemaParser from '../util/raml-1-0-parser.js';
 import { isValidJsonOrYaml } from '../../../utils/spec-valid-json-yaml.js';
+import AsyncAPIValidationPane from './AsyncAPIValidationPane.jsx';
 
 registerSchemaParser(openapiSchemaParser);
 registerSchemaParser(ramlSchemaParser);
@@ -63,6 +64,7 @@ const removeDuplicateMarkers = (list) => {
 const AsyncAPIEditorPreviewPane = ({ specSelectors, editorActions }) => {
   const [isValid, setIsValid] = useState(false);
   const [parsedSpec, setParsedSpec] = useState(null);
+  const [markers, setMarkers] = useState([]);
 
   const useDebounce = (value, delay) => {
     // eslint-disable-next-line no-unused-vars
@@ -106,7 +108,9 @@ const AsyncAPIEditorPreviewPane = ({ specSelectors, editorActions }) => {
             const allErrorMarkers = validationErrorMarkers.concat(refErrorMarkers);
             const dedupedErrorMarkers = removeDuplicateMarkers(allErrorMarkers);
             // update reducer state
-            editorActions.updateEditorMarkers(dedupedErrorMarkers);
+            // editorActions.updateEditorMarkers(dedupedErrorMarkers);
+            // update local state for now
+            setMarkers(dedupedErrorMarkers);
             setIsValid(false);
           });
       }, delay);
@@ -138,6 +142,7 @@ const AsyncAPIEditorPreviewPane = ({ specSelectors, editorActions }) => {
         <p style={{ paddingLeft: '2.0rem' }}>
           Empty or invalid document. Please fix errors/define AsyncAPI document.
         </p>
+        <AsyncAPIValidationPane markers={markers} editorActions={editorActions} />
       </div>
     );
   }

--- a/src/plugins/editor-preview-asyncapi/components/AsyncAPIEditorPreviewPane.jsx
+++ b/src/plugins/editor-preview-asyncapi/components/AsyncAPIEditorPreviewPane.jsx
@@ -7,7 +7,6 @@ import * as avroSchemaParser from '@asyncapi/avro-schema-parser';
 
 import * as ramlSchemaParser from '../util/raml-1-0-parser.js';
 import { isValidJsonOrYaml } from '../../../utils/spec-valid-json-yaml.js';
-import AsyncAPIValidationPane from './AsyncAPIValidationPane.jsx';
 
 registerSchemaParser(openapiSchemaParser);
 registerSchemaParser(ramlSchemaParser);
@@ -66,6 +65,7 @@ const AsyncAPIEditorPreviewPane = ({
   editorActions,
   asyncapiActions,
   asyncapiSelectors,
+  getComponent,
 }) => {
   const [isValid, setIsValid] = useState(false);
   const [parsedSpec, setParsedSpec] = useState(null);
@@ -138,10 +138,12 @@ const AsyncAPIEditorPreviewPane = ({
       errors: true, // config setting to show error pane
     },
   };
+  const EditorPreviewValidationPane = getComponent('AsyncApiPreviewValidationPane', true);
+
   if (!isValid) {
     return (
       <div className="swagger-editor__asyncapi-container">
-        <AsyncAPIValidationPane
+        <EditorPreviewValidationPane
           asyncapiSelectors={asyncapiSelectors}
           editorActions={editorActions}
         />
@@ -160,6 +162,7 @@ AsyncAPIEditorPreviewPane.propTypes = {
   editorActions: PropTypes.oneOfType([PropTypes.object]).isRequired,
   asyncapiSelectors: PropTypes.oneOfType([PropTypes.object]).isRequired,
   asyncapiActions: PropTypes.oneOfType([PropTypes.object]).isRequired,
+  getComponent: PropTypes.func.isRequired,
 };
 
 export default AsyncAPIEditorPreviewPane;

--- a/src/plugins/editor-preview-asyncapi/components/AsyncAPIEditorPreviewPane.jsx
+++ b/src/plugins/editor-preview-asyncapi/components/AsyncAPIEditorPreviewPane.jsx
@@ -61,10 +61,14 @@ const removeDuplicateMarkers = (list) => {
   }, []);
 };
 
-const AsyncAPIEditorPreviewPane = ({ specSelectors, editorActions }) => {
+const AsyncAPIEditorPreviewPane = ({
+  specSelectors,
+  editorActions,
+  asyncapiActions,
+  asyncapiSelectors,
+}) => {
   const [isValid, setIsValid] = useState(false);
   const [parsedSpec, setParsedSpec] = useState(null);
-  const [markers, setMarkers] = useState([]);
 
   const useDebounce = (value, delay) => {
     // eslint-disable-next-line no-unused-vars
@@ -108,9 +112,7 @@ const AsyncAPIEditorPreviewPane = ({ specSelectors, editorActions }) => {
             const allErrorMarkers = validationErrorMarkers.concat(refErrorMarkers);
             const dedupedErrorMarkers = removeDuplicateMarkers(allErrorMarkers);
             // update reducer state
-            // editorActions.updateEditorMarkers(dedupedErrorMarkers);
-            // update local state for now
-            setMarkers(dedupedErrorMarkers);
+            asyncapiActions.updateAsyncApiParserMarkers(dedupedErrorMarkers);
             setIsValid(false);
           });
       }, delay);
@@ -139,7 +141,10 @@ const AsyncAPIEditorPreviewPane = ({ specSelectors, editorActions }) => {
   if (!isValid) {
     return (
       <div className="swagger-editor__asyncapi-container">
-        <AsyncAPIValidationPane markers={markers} editorActions={editorActions} />
+        <AsyncAPIValidationPane
+          asyncapiSelectors={asyncapiSelectors}
+          editorActions={editorActions}
+        />
       </div>
     );
   }
@@ -153,6 +158,8 @@ const AsyncAPIEditorPreviewPane = ({ specSelectors, editorActions }) => {
 AsyncAPIEditorPreviewPane.propTypes = {
   specSelectors: PropTypes.oneOfType([PropTypes.object]).isRequired,
   editorActions: PropTypes.oneOfType([PropTypes.object]).isRequired,
+  asyncapiSelectors: PropTypes.oneOfType([PropTypes.object]).isRequired,
+  asyncapiActions: PropTypes.oneOfType([PropTypes.object]).isRequired,
 };
 
 export default AsyncAPIEditorPreviewPane;

--- a/src/plugins/editor-preview-asyncapi/components/AsyncAPIEditorPreviewPane.jsx
+++ b/src/plugins/editor-preview-asyncapi/components/AsyncAPIEditorPreviewPane.jsx
@@ -138,10 +138,7 @@ const AsyncAPIEditorPreviewPane = ({ specSelectors, editorActions }) => {
   };
   if (!isValid) {
     return (
-      <div className="flex flex-1 overflow-hidden h-full justify-center items-center text-2xl mx-auto px-6 text-center">
-        <p style={{ paddingLeft: '2.0rem' }}>
-          Empty or invalid document. Please fix errors/define AsyncAPI document.
-        </p>
+      <div className="swagger-editor__asyncapi-container">
         <AsyncAPIValidationPane markers={markers} editorActions={editorActions} />
       </div>
     );

--- a/src/plugins/editor-preview-asyncapi/components/AsyncAPIEditorPreviewPane.jsx
+++ b/src/plugins/editor-preview-asyncapi/components/AsyncAPIEditorPreviewPane.jsx
@@ -145,7 +145,7 @@ const AsyncAPIEditorPreviewPane = ({
       <div className="swagger-editor__asyncapi-container">
         <EditorPreviewValidationPane
           asyncapiSelectors={asyncapiSelectors}
-          editorActions={editorActions}
+          onValidationClick={editorActions.setJumpToEditorMarker}
         />
       </div>
     );

--- a/src/plugins/editor-preview-asyncapi/components/AsyncAPIValidationPane.jsx
+++ b/src/plugins/editor-preview-asyncapi/components/AsyncAPIValidationPane.jsx
@@ -34,13 +34,16 @@ const AsyncAPIValidationPane = ({
   };
 
   return (
-    <div className="swagger-editor__validation-pane">
+    <div className="swagger-editor__asyncapi-validation-pane">
       {showTable && (
-        <ValidationTable
-          columns={columns}
-          data={data}
-          onValidationKeyClick={handleValidationClick}
-        />
+        <>
+          <h4>Invalid AsyncAPI document. Please fix errors:</h4>
+          <ValidationTable
+            columns={columns}
+            data={data}
+            onValidationKeyClick={handleValidationClick}
+          />
+        </>
       )}
     </div>
   );

--- a/src/plugins/editor-preview-asyncapi/components/AsyncAPIValidationPane.jsx
+++ b/src/plugins/editor-preview-asyncapi/components/AsyncAPIValidationPane.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import ValidationTable from '../../editor-monaco/components/ValidationTable/ValidationTable.jsx';
+
+const AsyncAPIValidationPane = ({
+  // editorSelectors,
+  editorActions,
+  onValidationClick,
+  alwaysDisplayHeading,
+  markers,
+}) => {
+  // const markers = editorSelectors.selectEditorMarkers();
+  const columns = React.useMemo(
+    () => [
+      {
+        Header: 'Line',
+        accessor: 'startLineNumber',
+      },
+      {
+        Header: 'Description',
+        accessor: 'message',
+      },
+    ],
+    []
+  );
+  // const data = React.useMemo(() => markers, [markers]);
+  const data = markers;
+  const showTable = alwaysDisplayHeading || data.length > 0;
+
+  const handleValidationClick = (marker) => {
+    onValidationClick(marker);
+    editorActions.setJumpToEditorMarker(marker);
+  };
+
+  return (
+    <div className="swagger-editor__validation-pane">
+      {showTable && (
+        <ValidationTable
+          columns={columns}
+          data={data}
+          onValidationKeyClick={handleValidationClick}
+        />
+      )}
+    </div>
+  );
+};
+
+AsyncAPIValidationPane.propTypes = {
+  markers: PropTypes.oneOfType([PropTypes.array]).isRequired,
+  alwaysDisplayHeading: PropTypes.bool,
+  editorActions: PropTypes.oneOfType([PropTypes.object]).isRequired,
+  // editorSelectors: PropTypes.oneOfType([PropTypes.object]).isRequired,
+  onValidationClick: PropTypes.func,
+};
+
+AsyncAPIValidationPane.defaultProps = {
+  alwaysDisplayHeading: false,
+  onValidationClick: () => {},
+};
+
+export default AsyncAPIValidationPane;

--- a/src/plugins/editor-preview-asyncapi/components/AsyncAPIValidationPane.jsx
+++ b/src/plugins/editor-preview-asyncapi/components/AsyncAPIValidationPane.jsx
@@ -4,13 +4,12 @@ import PropTypes from 'prop-types';
 import ValidationTable from '../../editor-monaco/components/ValidationTable/ValidationTable.jsx';
 
 const AsyncAPIValidationPane = ({
-  // editorSelectors,
+  asyncapiSelectors,
   editorActions,
   onValidationClick,
   alwaysDisplayHeading,
-  markers,
 }) => {
-  // const markers = editorSelectors.selectEditorMarkers();
+  const markers = asyncapiSelectors.selectAsyncApiParserMarkers();
   const columns = React.useMemo(
     () => [
       {
@@ -24,8 +23,7 @@ const AsyncAPIValidationPane = ({
     ],
     []
   );
-  // const data = React.useMemo(() => markers, [markers]);
-  const data = markers;
+  const data = React.useMemo(() => markers, [markers]);
   const showTable = alwaysDisplayHeading || data.length > 0;
 
   const handleValidationClick = (marker) => {
@@ -50,10 +48,9 @@ const AsyncAPIValidationPane = ({
 };
 
 AsyncAPIValidationPane.propTypes = {
-  markers: PropTypes.oneOfType([PropTypes.array]).isRequired,
   alwaysDisplayHeading: PropTypes.bool,
   editorActions: PropTypes.oneOfType([PropTypes.object]).isRequired,
-  // editorSelectors: PropTypes.oneOfType([PropTypes.object]).isRequired,
+  asyncapiSelectors: PropTypes.oneOfType([PropTypes.object]).isRequired,
   onValidationClick: PropTypes.func,
 };
 

--- a/src/plugins/editor-preview-asyncapi/components/AsyncApiPreviewValidationPane.jsx
+++ b/src/plugins/editor-preview-asyncapi/components/AsyncApiPreviewValidationPane.jsx
@@ -5,7 +5,6 @@ import ValidationTable from '../../editor-monaco/components/ValidationTable/Vali
 
 const AsyncApiPreviewValidationPane = ({
   asyncapiSelectors,
-  editorActions,
   onValidationClick,
   alwaysDisplayHeading,
 }) => {
@@ -28,7 +27,6 @@ const AsyncApiPreviewValidationPane = ({
 
   const handleValidationClick = (marker) => {
     onValidationClick(marker);
-    editorActions.setJumpToEditorMarker(marker);
   };
 
   return (
@@ -49,7 +47,6 @@ const AsyncApiPreviewValidationPane = ({
 
 AsyncApiPreviewValidationPane.propTypes = {
   alwaysDisplayHeading: PropTypes.bool,
-  editorActions: PropTypes.oneOfType([PropTypes.object]).isRequired,
   asyncapiSelectors: PropTypes.oneOfType([PropTypes.object]).isRequired,
   onValidationClick: PropTypes.func,
 };

--- a/src/plugins/editor-preview-asyncapi/components/AsyncApiPreviewValidationPane.jsx
+++ b/src/plugins/editor-preview-asyncapi/components/AsyncApiPreviewValidationPane.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import ValidationTable from '../../editor-monaco/components/ValidationTable/ValidationTable.jsx';
 
-const AsyncAPIValidationPane = ({
+const AsyncApiPreviewValidationPane = ({
   asyncapiSelectors,
   editorActions,
   onValidationClick,
@@ -47,16 +47,16 @@ const AsyncAPIValidationPane = ({
   );
 };
 
-AsyncAPIValidationPane.propTypes = {
+AsyncApiPreviewValidationPane.propTypes = {
   alwaysDisplayHeading: PropTypes.bool,
   editorActions: PropTypes.oneOfType([PropTypes.object]).isRequired,
   asyncapiSelectors: PropTypes.oneOfType([PropTypes.object]).isRequired,
   onValidationClick: PropTypes.func,
 };
 
-AsyncAPIValidationPane.defaultProps = {
+AsyncApiPreviewValidationPane.defaultProps = {
   alwaysDisplayHeading: false,
   onValidationClick: () => {},
 };
 
-export default AsyncAPIValidationPane;
+export default AsyncApiPreviewValidationPane;

--- a/src/plugins/editor-preview-asyncapi/components/AsyncApiPreviewValidationPane.test.js
+++ b/src/plugins/editor-preview-asyncapi/components/AsyncApiPreviewValidationPane.test.js
@@ -3,7 +3,6 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import AsyncApiPreviewValidationPane from './AsyncApiPreviewValidationPane.jsx';
 import * as asyncapiSelectors from '../selectors.js';
-import * as editorActions from '../../editor-monaco/actions.js';
 
 jest.mock('../selectors.js', () => ({
   selectAsyncApiParserMarkers: jest.fn(),
@@ -17,7 +16,7 @@ const setup = ({ markerErrorList } = {}) => {
   asyncapiSelectors.selectAsyncApiParserMarkers.mockReturnValue(markerErrorList);
   const onValidationClick = jest.fn();
   const alwaysDisplayHeading = true;
-  return { asyncapiSelectors, editorActions, onValidationClick, alwaysDisplayHeading };
+  return { asyncapiSelectors, onValidationClick, alwaysDisplayHeading };
 };
 
 const renderValidationPane = async (props) => {
@@ -49,7 +48,6 @@ describe('with empty errorMarkerErrorList', () => {
       alwaysDisplayHeading,
       onValidationClick,
       asyncapiSelectors: selectors,
-      editorActions: actions,
     } = setup({
       markerErrorList: [],
     });
@@ -57,7 +55,6 @@ describe('with empty errorMarkerErrorList', () => {
       alwaysDisplayHeading,
       onValidationClick,
       asyncapiSelectors: selectors,
-      editorActions: actions,
     });
 
     const elementHeaderExists1 = hasTableItem('Line');
@@ -80,7 +77,6 @@ describe('with populated markerErrorList', () => {
       alwaysDisplayHeading,
       onValidationClick,
       asyncapiSelectors: selectors,
-      editorActions: actions,
     } = setup({
       markerErrorList: [
         {
@@ -97,7 +93,6 @@ describe('with populated markerErrorList', () => {
       alwaysDisplayHeading,
       onValidationClick,
       asyncapiSelectors: selectors,
-      editorActions: actions,
     });
 
     const elementRowExists1 = hasTableItem(columnMessage1);

--- a/src/plugins/editor-preview-asyncapi/components/AsyncApiPreviewValidationPane.test.js
+++ b/src/plugins/editor-preview-asyncapi/components/AsyncApiPreviewValidationPane.test.js
@@ -1,0 +1,119 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import AsyncApiPreviewValidationPane from './AsyncApiPreviewValidationPane.jsx';
+import * as asyncapiSelectors from '../selectors.js';
+import * as editorActions from '../../editor-monaco/actions.js';
+
+jest.mock('../selectors.js', () => ({
+  selectAsyncApiParserMarkers: jest.fn(),
+}));
+
+afterAll(() => {
+  jest.unmock('../selectors.js');
+});
+
+const setup = ({ markerErrorList } = {}) => {
+  asyncapiSelectors.selectAsyncApiParserMarkers.mockReturnValue(markerErrorList);
+  const onValidationClick = jest.fn();
+  const alwaysDisplayHeading = true;
+  return { asyncapiSelectors, editorActions, onValidationClick, alwaysDisplayHeading };
+};
+
+const renderValidationPane = async (props) => {
+  render(
+    // eslint-disable-next-line react/jsx-filename-extension
+    <AsyncApiPreviewValidationPane
+      {...props} // eslint-disable-line react/jsx-props-no-spreading
+    />
+  );
+
+  await waitFor(() => expect(asyncapiSelectors.selectAsyncApiParserMarkers).toBeCalled());
+  return {
+    hasTableItem: (selector) => {
+      const item = screen.queryByText(selector, { exact: false });
+      if (!item) {
+        return false;
+      }
+      return true;
+    },
+    clickTableItem: (selector) => fireEvent.click(screen.getByText(selector)),
+  };
+};
+
+describe('with empty errorMarkerErrorList', () => {
+  test('should render with table headers and no table rows', async () => {
+    const columnMessage1 = 'should always have a title';
+
+    const {
+      alwaysDisplayHeading,
+      onValidationClick,
+      asyncapiSelectors: selectors,
+      editorActions: actions,
+    } = setup({
+      markerErrorList: [],
+    });
+    const { hasTableItem } = await renderValidationPane({
+      alwaysDisplayHeading,
+      onValidationClick,
+      asyncapiSelectors: selectors,
+      editorActions: actions,
+    });
+
+    const elementHeaderExists1 = hasTableItem('Line');
+    expect(elementHeaderExists1).toBe(true);
+    const elementHeaderExists2 = hasTableItem('Description');
+    expect(elementHeaderExists2).toBe(true);
+    const elementRowExists1 = hasTableItem(columnMessage1);
+    expect(elementRowExists1).toBe(false);
+  });
+});
+
+describe('with populated markerErrorList', () => {
+  test('should respond to clickEvent within table rows', async () => {
+    const columnMessage1 = 'should always have a title';
+    const columnMessage2 = 'should always have a description';
+    const columnStartLineNumber1 = 2;
+    const columnStartLineNumber2 = 3;
+
+    const {
+      alwaysDisplayHeading,
+      onValidationClick,
+      asyncapiSelectors: selectors,
+      editorActions: actions,
+    } = setup({
+      markerErrorList: [
+        {
+          startLineNumber: columnStartLineNumber1,
+          message: columnMessage1,
+        },
+        {
+          startLineNumber: columnStartLineNumber2,
+          message: columnMessage2,
+        },
+      ],
+    });
+    const { hasTableItem, clickTableItem } = await renderValidationPane({
+      alwaysDisplayHeading,
+      onValidationClick,
+      asyncapiSelectors: selectors,
+      editorActions: actions,
+    });
+
+    const elementRowExists1 = hasTableItem(columnMessage1);
+    expect(elementRowExists1).toBe(true);
+    const elementRowExists2 = hasTableItem(columnMessage2);
+    expect(elementRowExists2).toBe(true);
+
+    clickTableItem(columnMessage1);
+    expect(onValidationClick).toBeCalled();
+    expect(onValidationClick).toBeCalledTimes(1);
+
+    clickTableItem(columnStartLineNumber2);
+    expect(onValidationClick).toBeCalled();
+    expect(onValidationClick).toBeCalledTimes(2);
+
+    expect(onValidationClick.mock.calls[0][0].message).toBe(columnMessage1);
+    expect(onValidationClick.mock.calls[1][0].startLineNumber).toBe(columnStartLineNumber2);
+  });
+});

--- a/src/plugins/editor-preview-asyncapi/components/_all.scss
+++ b/src/plugins/editor-preview-asyncapi/components/_all.scss
@@ -1,0 +1,1 @@
+@import './asyncapi';

--- a/src/plugins/editor-preview-asyncapi/components/_asyncapi.scss
+++ b/src/plugins/editor-preview-asyncapi/components/_asyncapi.scss
@@ -1,0 +1,14 @@
+.swagger-editor {
+  &__asyncapi-container {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__asyncapi-validation-pane {
+    flex: 0 0 auto;
+    overflow-y: auto;
+    max-height: none;
+    padding-left: 2rem;
+    padding-right: 2rem;
+  }
+}

--- a/src/plugins/editor-preview-asyncapi/index.js
+++ b/src/plugins/editor-preview-asyncapi/index.js
@@ -1,6 +1,12 @@
 import AsyncAPIEditorPreviewPane from './components/AsyncAPIEditorPreviewPane.jsx';
 import EditorPreviewPaneWrapper from './wrap-components/EditorPreviewPaneWrapper.jsx';
-import { getIsOasOrAsyncApi2, shouldUpdateDefinitionLanguage } from './actions.js';
+import {
+  getIsOasOrAsyncApi2,
+  shouldUpdateDefinitionLanguage,
+  updateAsyncApiParserMarkers,
+} from './actions.js';
+import reducers from './reducers.js';
+import { selectAsyncApiParserMarkers } from './selectors.js';
 
 const EditorPreviewAsyncAPIPlugin = () => ({
   components: {
@@ -14,7 +20,10 @@ const EditorPreviewAsyncAPIPlugin = () => ({
       actions: {
         getIsOasOrAsyncApi2,
         shouldUpdateDefinitionLanguage,
+        updateAsyncApiParserMarkers,
       },
+      reducers,
+      selectors: { selectAsyncApiParserMarkers },
     },
   },
 });

--- a/src/plugins/editor-preview-asyncapi/index.js
+++ b/src/plugins/editor-preview-asyncapi/index.js
@@ -1,4 +1,5 @@
 import AsyncAPIEditorPreviewPane from './components/AsyncAPIEditorPreviewPane.jsx';
+import AsyncApiPreviewValidationPane from './components/AsyncApiPreviewValidationPane.jsx';
 import EditorPreviewPaneWrapper from './wrap-components/EditorPreviewPaneWrapper.jsx';
 import {
   getIsOasOrAsyncApi2,
@@ -11,6 +12,7 @@ import { selectAsyncApiParserMarkers } from './selectors.js';
 const EditorPreviewAsyncAPIPlugin = () => ({
   components: {
     AsyncAPIEditorPreviewPane,
+    AsyncApiPreviewValidationPane,
   },
   wrapComponents: {
     EditorPreviewPane: EditorPreviewPaneWrapper,

--- a/src/plugins/editor-preview-asyncapi/reducers.js
+++ b/src/plugins/editor-preview-asyncapi/reducers.js
@@ -1,0 +1,9 @@
+import { ASYNCAPI_PARSER_ERROR_MARKERS } from './actions.js';
+
+const reducers = {
+  [ASYNCAPI_PARSER_ERROR_MARKERS]: (state, action) => {
+    return state.set('asyncapiParserMarkers', action.payload);
+  },
+};
+
+export default reducers;

--- a/src/plugins/editor-preview-asyncapi/selectors.js
+++ b/src/plugins/editor-preview-asyncapi/selectors.js
@@ -1,0 +1,9 @@
+/* eslint-disable import/prefer-default-export */
+import { createSelector } from 'reselect';
+
+export const selectAsyncApiParserMarkers = createSelector(
+  (state) => state.get('asyncapiParserMarkers'),
+  (asyncapiMarkers) => {
+    return asyncapiMarkers || [];
+  }
+);

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -3,6 +3,7 @@
 @import '../plugins/layout/components/all';
 @import '../plugins/editor-textarea/components/all';
 @import '../plugins/editor-monaco/components/all';
+@import '../plugins/editor-preview-asyncapi/components/all';
 
 .ReactModalPortal {
   @import './modal';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

`EditorPreviewPane` for AsyncAPI now contains its own separate ValidationPane. This new ValidationPane displays the results from the asyncapi/parser, and maintains the error message to user to fix the errors (while not rendering AsyncApi-React). 

The additional benefit is that `EditorPreviewPane` now displays more detailed error messages indicating why AsyncApi-React is unable to render.

`Jump to Marker` feature also works, matching the behavior of `EditorPane`'s `ValidationPane`, e.g. clicking on the error will cause the pointer to move to the appropriate line in `EditorPane`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

AsyncAPI definitions are first parsed by AsyncApi's own parser. If parsing fails, AsyncApi-React will be unable to render the definition. 
Current issues:
- parsing errors resulting from the `asyncpi/parser` has a different error shape than parsing errors from `apidom-ls`.
- sharing the `ValidationPane` within the `EditorPane` can cause async visual conflicts depending on which parser returns errors "later".
- `apidom-ls` and `asyncapi/parser` can return different errors and different error counts.



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

new unit tests

### Screenshots (if appropriate):

![s-ide-801-fixed](https://user-images.githubusercontent.com/12902658/174395457-0cb2d9ad-06c4-4042-8041-a5c8460706f2.png)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
