### PR TITLE
feat: skip validation for unrecognized specifications/formats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@emotion/styled": "^11.9.3",
         "@mui/material": "^5.8.4",
         "@primer/octicons-react": "^17.3.0",
-        "@swagger-api/apidom-ls": "^0.30.1",
+        "@swagger-api/apidom-ls": "^0.31.0",
         "axios": "^0.27.2",
         "deepmerge": "^4.2.2",
         "file-dialog": "^0.0.8",
@@ -3906,70 +3906,70 @@
       }
     },
     "node_modules/@swagger-api/apidom-ast": {
-      "version": "0.30.0",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-ast/0.30.0/3dd8e5d23ce5d03e83244e9a1d94c5d1c3424a4dc8048ec6e08e7e591463f6f3",
-      "integrity": "sha512-24whuAT2rGfsU3PMx7eFENxYsYdTvQSVt/CtS/VD7nbyXvxsQLOe2Bl4gzRYRxKMhQdA5CT4pWehTXOEZZu81w==",
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-ast/0.31.0/91014600f569882533b550335b346112800199e9601839f7988146178dce841a",
+      "integrity": "sha512-1JFHmmq4kvcQYrr8u/8nLptHH+pImgpyymJnMEHqcnM/vczGBhfCMHdXan2IPnIcTF8ZN0q2i5Cm8hnpx+n/pg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "=7.18.3",
         "@types/ramda": "=0.28.14",
         "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.1.0",
+        "ramda-adjunct": "=3.2.0",
         "stampit": "=4.3.2",
         "unraw": "=2.0.1"
       }
     },
     "node_modules/@swagger-api/apidom-core": {
-      "version": "0.30.0",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-core/0.30.0/17b0a4266e1603b869699fadc52076eec55eab5890e214b5e041737e802f039d",
-      "integrity": "sha512-jBcYXyudspcjoheNGd9YBAXedMbywJVCyL7GFYV/h4KurNbpZ2a5A1woL+VvEjvwnnB5CmEa7wPE/qAJYYjMsg==",
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-core/0.31.0/376e658dcda4ddc9a53a46e08bd8512ee6eb35145bfa10920d061dcec2218942",
+      "integrity": "sha512-j1+SRvCFfbz2ZHTz/cHV7Wy4NoHPlb0n+7ZyJ8YCk16or606wvti/gYLLPL5I+joRxx+/CcDfo3/PMQCWylC8g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "=7.18.3",
-        "@swagger-api/apidom-ast": "^0.30.0",
+        "@swagger-api/apidom-ast": "^0.31.0",
         "@types/ramda": "=0.28.14",
         "minim": "=0.23.8",
         "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.1.0",
+        "ramda-adjunct": "=3.2.0",
         "short-unique-id": "=4.4.4",
         "stampit": "=4.3.2"
       }
     },
     "node_modules/@swagger-api/apidom-json-pointer": {
-      "version": "0.30.0",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-json-pointer/0.30.0/1da05381f7b3a728561825c953e62abb2004fe27e27d95a8f6c2ff6017327348",
-      "integrity": "sha512-sBkyYUaMaYEGITdJ9TLahcHsvz95e7s9HLOjkTT2ESVf27feVE5MgtyFld9AT3tENSXEDFiIXbEWGXpcSgZkIg==",
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-json-pointer/0.31.0/4aaaf960e5408f1931a43057c1f146078aebc791ec9a11113b1b445d06ddca43",
+      "integrity": "sha512-gezS6frzKMaWQ3NR5Vhzrz/GfEsWDE7mhocQZUBF4a0U/2+qwv7i29HF0KEwKzYqMCMXm7E1eSLD2pVyD7tUrw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "=7.18.3",
-        "@swagger-api/apidom-core": "^0.30.0",
+        "@swagger-api/apidom-core": "^0.31.0",
         "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.1.0"
+        "ramda-adjunct": "=3.2.0"
       }
     },
     "node_modules/@swagger-api/apidom-ls": {
-      "version": "0.30.1",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-ls/0.30.1/1c43cd86517f8ced16d1ceb9866e13383be332af864efe14071d856687bed9df",
-      "integrity": "sha512-hfXNb9RkVU08NgOB75YDrH+YNSGFwa0iSjUGH5Brh3YEIv8+OCwH3vq4i8XTCFvfAfwfFN/b8dUTylBMApReuA==",
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-ls/0.31.0/62088bf6672ecf503e406d7bb685e105ba34f13d12526d345858133a475afa5a",
+      "integrity": "sha512-/EELWyImf3rndJTXxj/AXBn2oMuuyK+w7M1mLM/1ohtAPONXkVN7LxZtbHLONxtYAETmzrtnhusw5QJ6GgS57Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "=7.18.3",
-        "@swagger-api/apidom-core": "^0.30.0",
-        "@swagger-api/apidom-json-pointer": "^0.30.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.30.0",
-        "@swagger-api/apidom-parser": "^0.30.0",
-        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^0.30.1",
-        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^0.30.1",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^0.30.1",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^0.30.1",
-        "@swagger-api/apidom-reference": "^0.30.1",
+        "@swagger-api/apidom-core": "^0.31.0",
+        "@swagger-api/apidom-json-pointer": "^0.31.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.31.0",
+        "@swagger-api/apidom-parser": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^0.31.0",
+        "@swagger-api/apidom-reference": "^0.31.0",
         "@types/ramda": "=0.28.14",
         "ajv": "^8.6.3",
         "ajv-errors": "^3.0.0",
         "ajv-formats": "^2.1.1",
         "json-source-map": "^0.6.1",
         "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.1.0",
+        "ramda-adjunct": "=3.2.0",
         "stampit": "=4.3.2",
         "vscode-languageserver-protocol": "^3.16.0",
         "vscode-languageserver-textdocument": "^1.0.1",
@@ -4005,90 +4005,135 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
-    "node_modules/@swagger-api/apidom-ns-asyncapi-2": {
-      "version": "0.30.0",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-ns-asyncapi-2/0.30.0/577b1e902206454583b3e11803dca79ff70ded2613d2b48f69ed5712f3008180",
-      "integrity": "sha512-37dIo579lsrO0r4axMUHSNcEz+ScSw3MWTohL1wyQqxBCxeslXytgYtqccypKr8zuiYrUNopIxk4HznUTQfKpQ==",
+    "node_modules/@swagger-api/apidom-ns-api-design-systems": {
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-ns-api-design-systems/0.31.0/83a6bf465977aacff7d92ae522fd804d79994e20f8ce80c6fe07464b4baa4515",
+      "integrity": "sha512-QVUlL4cQGcvP9I193PwRxS7lv8ZLDHkTsVchRpW0Mje/ueYAlpRyEvrcSiEkLR+h2Ly+ol37GUoebhMgIoyAbg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "=7.18.3",
-        "@swagger-api/apidom-core": "^0.30.0",
+        "@swagger-api/apidom-core": "^0.31.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.31.0",
         "@types/ramda": "=0.28.14",
         "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.1.0",
+        "ramda-adjunct": "=3.2.0",
+        "stampit": "=4.3.2"
+      }
+    },
+    "node_modules/@swagger-api/apidom-ns-asyncapi-2": {
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-ns-asyncapi-2/0.31.0/fde7a31e3008b24cb403680cc98384ef82dede661a142f9ef60ae898da75f5a3",
+      "integrity": "sha512-rAFfy9H8ogqNHgFajkPtMTtoAcWNg70voL2btns3godNQgclPJyhpO1vDhM1JCYhFSuyxZEn8EvUMQGw1qGxVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime-corejs3": "=7.18.3",
+        "@swagger-api/apidom-core": "^0.31.0",
+        "@types/ramda": "=0.28.14",
+        "ramda": "=0.28.0",
+        "ramda-adjunct": "=3.2.0",
         "stampit": "=4.3.2"
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-1": {
-      "version": "0.30.0",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-ns-openapi-3-1/0.30.0/1acbd06d1e21ad022b7e0645758bdceadc54220292b8fd271e8ee7e3cc37f747",
-      "integrity": "sha512-UjghFpee1TLSsDD/hybmy2ix+ZSfxeklrlpIH6CzIM6ytUOA7Fpni787mhA8jD88qkn4Acuj/mxfsAxh9vG1dA==",
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-ns-openapi-3-1/0.31.0/6430ca6b22c2305ab3f6fdda29d2a786bf6fe45ad2a0437b5454290c635afa4d",
+      "integrity": "sha512-3iXCLqTW/mrlgG9/CyMvHvng8qChNKREFgaXpraZVsaoGiM3jDvkLmpVAwJT8IrLTeYrbRBKUbZOPzuIrJQz7A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "=7.18.3",
-        "@swagger-api/apidom-core": "^0.30.0",
+        "@swagger-api/apidom-core": "^0.31.0",
         "@types/ramda": "=0.28.14",
         "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.1.0",
+        "ramda-adjunct": "=3.2.0",
         "stampit": "=4.3.2"
       }
     },
     "node_modules/@swagger-api/apidom-parser": {
-      "version": "0.30.0",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser/0.30.0/b5c874b9bfa95801a41406cbeced6079600b473ef1d2aa75964623220a73d71d",
-      "integrity": "sha512-tzslUdcfBvN/M7s6yI1wcY/UZQ22G7I1k7SRJMsyXNMDVsyGde4c7rINCL3d+w2UXjWm9yQ8p5U3TG6xrhhnXA==",
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser/0.31.0/94b17e0f6f64284ba79bd85e623133d9c02dc14834adc8c51d7d42afb4f2a1cd",
+      "integrity": "sha512-eWgnLi/bVpR47ItFisbKEzjD9qPoxCIlzGQYISmqpEPy5b7qzhYgTJdct1U3DPzadU8ifOwmnSYFXu+J0WwLLQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "=7.18.3",
-        "@swagger-api/apidom-core": "^0.30.0",
+        "@swagger-api/apidom-core": "^0.31.0",
         "@types/ramda": "=0.28.14",
         "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.1.0",
+        "ramda-adjunct": "=3.2.0",
         "stampit": "=4.3.2"
       }
     },
-    "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
-      "version": "0.30.1",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser-adapter-asyncapi-json-2/0.30.1/c4bd647b83398a8deae29d17288f7bcb0cfcc46f87f88a4bc258705c3b4d085d",
-      "integrity": "sha512-d/PVIWHpiEjiaQtfVAmsxrLBd8a660KoaSfO8xoLwexcmMqeerVRe3QMAITulEGOHyJ32p7+E66ZSdyYI9VadA==",
+    "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json": {
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser-adapter-api-design-systems-json/0.31.0/e271750e5464060c3bfdeb98c2d0b143ab5e0218803341def74e9803afbbbf17",
+      "integrity": "sha512-ipLhNBGnZsb9guqaMAi9dBxpj7oeRSS7Ac72+ZkIIabUfQzg6i6Tw84SBsfl/FhAJ7rknRdMVt42MrOYHnjafQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "=7.18.3",
-        "@swagger-api/apidom-core": "^0.30.0",
-        "@swagger-api/apidom-ns-asyncapi-2": "^0.30.0",
-        "@swagger-api/apidom-parser-adapter-json": "^0.30.1",
+        "@swagger-api/apidom-core": "^0.31.0",
+        "@swagger-api/apidom-ns-api-design-systems": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-json": "^0.31.0",
         "@types/ramda": "=0.28.14",
         "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.1.0"
+        "ramda-adjunct": "=3.2.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/0.31.0/fb20c0972689177a371eee43c6ef23500755aeb853ee1237d09d29a19df6465e",
+      "integrity": "sha512-ynJ1QrvNouCIUNkylEZCfXLbyaTElkqFHddzyOr9EBZsT5qsFqPYhDXrwst//SXEKZ8MhXlZR+w8Bxl0M91sjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime-corejs3": "=7.18.3",
+        "@swagger-api/apidom-core": "^0.31.0",
+        "@swagger-api/apidom-ns-api-design-systems": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.31.0",
+        "@types/ramda": "=0.28.14",
+        "ramda": "=0.28.0",
+        "ramda-adjunct": "=3.2.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser-adapter-asyncapi-json-2/0.31.0/b84de0485604b06427098e81271f26396121e2c229b2331966639c15872dcea3",
+      "integrity": "sha512-ZspmO6oXeREnKcqPRGOJw/kXnXHbj3V1Kc5737advg+pU9brTcGDyk41T/HLx0j2VQNfEFi2zIpi57HrEpKY9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime-corejs3": "=7.18.3",
+        "@swagger-api/apidom-core": "^0.31.0",
+        "@swagger-api/apidom-ns-asyncapi-2": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-json": "^0.31.0",
+        "@types/ramda": "=0.28.14",
+        "ramda": "=0.28.0",
+        "ramda-adjunct": "=3.2.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
-      "version": "0.30.1",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/0.30.1/b351e09b63fff222463f49c7a38ac688eb9fbc7e431e1f5f5775d0c6ccb65b21",
-      "integrity": "sha512-j0cnaQrlFGd9xY+SYrIC9BG+tw+Q6N+YfYEZx2kFzZqEW5/L0pmxesr37pPLSiZgFsiOU+GfrREvkbtwVsi7kA==",
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/0.31.0/c7cb9eb0011d3912076b18aac14deba5311d0ae0abfcbd6ba2fde08332f39d0c",
+      "integrity": "sha512-6FgNPyaPfQmAmgn9vBYTpczqMRmQPsUczQSNT0Iv8KbsbTDPnaCyCzyDnvyhuxYQwEv/FXqyTxBKj6RGrKUvbQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "=7.18.3",
-        "@swagger-api/apidom-core": "^0.30.0",
-        "@swagger-api/apidom-ns-asyncapi-2": "^0.30.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.30.1",
+        "@swagger-api/apidom-core": "^0.31.0",
+        "@swagger-api/apidom-ns-asyncapi-2": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.31.0",
         "@types/ramda": "=0.28.14",
         "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.1.0"
+        "ramda-adjunct": "=3.2.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-json": {
-      "version": "0.30.1",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser-adapter-json/0.30.1/3c43795a4c174a73167b42880226e9a7ca58900810b822d07c36704fbf53c2e2",
-      "integrity": "sha512-5D2sp+yRiwGIop9Lza9u+3gAxuRpJBBylPIiNDB9T0dTAI/bKdVnIFcRjxIoMSNpPo1gSoAj5mCgOc2V1GaUWA==",
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser-adapter-json/0.31.0/fa51dd637c08f40056fd2ec7b8003170ed6dd3c249e23067f5301e09cd3d32e2",
+      "integrity": "sha512-tgwBMhDH4DQfP8Z5nlXyPV1bjDWihECN3iVKxeVBfqib+fMmaZ296llIFV3mu11qxy3JZGpT/mCgt6UmN72Qjg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "=7.18.3",
-        "@swagger-api/apidom-ast": "^0.30.0",
-        "@swagger-api/apidom-core": "^0.30.0",
+        "@swagger-api/apidom-ast": "^0.31.0",
+        "@swagger-api/apidom-core": "^0.31.0",
         "@types/ramda": "=0.28.14",
         "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.1.0",
+        "ramda-adjunct": "=3.2.0",
         "stampit": "=4.3.2",
         "tree-sitter": "=0.20.0",
         "tree-sitter-json": "=0.20.0",
@@ -4096,47 +4141,47 @@
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
-      "version": "0.30.1",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser-adapter-openapi-json-3-1/0.30.1/9717189134381d5b896ad77de00c9967a61b423d2b9431a43468d18effae09a5",
-      "integrity": "sha512-TnO4CubZzmsIxGA+N5b3bFY5WMqIM/UK6xvxDKnixTGwkMe6o4Qb3W6TRiKX6fDFi+B2vGLeLRruJgGTznN4aA==",
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser-adapter-openapi-json-3-1/0.31.0/6f380cef75a3e7c10d6718c1ea07bf4e705122c1538a8b0ea23b771eb42f9e86",
+      "integrity": "sha512-QIcj8Ov+JeHMsMy/5VjbjczdWOeHViSSTZAGKrojjPTOddsQRk8N8pNW4BWPIpi7fP2OK/FrrYVY6m6q3F6vbg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "=7.18.3",
-        "@swagger-api/apidom-core": "^0.30.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.30.0",
-        "@swagger-api/apidom-parser-adapter-json": "^0.30.1",
+        "@swagger-api/apidom-core": "^0.31.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-json": "^0.31.0",
         "@types/ramda": "=0.28.14",
         "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.1.0"
+        "ramda-adjunct": "=3.2.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
-      "version": "0.30.1",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/0.30.1/a82bad1991cb1020b21b93c3b8d5fd565a97ebb2b54b016dae4bdca6c1fefae7",
-      "integrity": "sha512-yJgK8AXk4RjTi6+z2pamTpVFbubU+cbUH6OTQLmWXg8AMV90ikTihMx2RCCgXhlQybEgMHsk/8DWPDw02PvJxQ==",
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/0.31.0/69ca96f53efcc491bbd791d220988bafa37ae2d39e63afcc4fd23e1c9ff24405",
+      "integrity": "sha512-cfzGxyg9MsbEBXFcjgMy612JKC9+fXiWK03B2zjKuw2J1uoqG20Ap5XJElT89N4ZgNrlBXV/M8JC4+Y6sV/6vw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "=7.18.3",
-        "@swagger-api/apidom-core": "^0.30.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.30.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.30.1",
+        "@swagger-api/apidom-core": "^0.31.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.31.0",
         "@types/ramda": "=0.28.14",
         "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.1.0"
+        "ramda-adjunct": "=3.2.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2": {
-      "version": "0.30.1",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser-adapter-yaml-1-2/0.30.1/b6c0869306639b0db080bd80c504b7a77ee2a8643c2d6e6539dc2a034b53078c",
-      "integrity": "sha512-pZSlpNIVOU/SmQ6rtlZ5bU6yPPs7UAWnL0Xc6lcCE3XD9Ecb9lRfdteFfR36vP26Xv+C6I7k5EC4EkcP1tLhaA==",
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser-adapter-yaml-1-2/0.31.0/f2c8d5d234d79ede6268531f23ea5e67e86b308f44531f7a6bc9b3420c5485a1",
+      "integrity": "sha512-/bBdRBzse7zZrVzfSRYctQX47LQhy+Sbh+tHqbH3H5JCgqAVaLTk9hukSrBN60tzstpUJW97OdZtT5OHiYbDRg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "=7.18.3",
-        "@swagger-api/apidom-ast": "^0.30.0",
-        "@swagger-api/apidom-core": "^0.30.0",
+        "@swagger-api/apidom-ast": "^0.31.0",
+        "@swagger-api/apidom-core": "^0.31.0",
         "@types/ramda": "=0.28.14",
         "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.1.0",
+        "ramda-adjunct": "=3.2.0",
         "stampit": "=4.3.2",
         "tree-sitter": "=0.20.0",
         "tree-sitter-yaml": "=0.5.0",
@@ -4144,27 +4189,29 @@
       }
     },
     "node_modules/@swagger-api/apidom-reference": {
-      "version": "0.30.1",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-reference/0.30.1/39aa622eeacb775093d06449daba43d2aee67ed5893b6c96688d2995ae35ab37",
-      "integrity": "sha512-VPwruNTirFifge8S4h2oYWrRaSCijMHSuEYOGa3jyF7vWJDfOAWZwIRHvS3Qon0udv0fFWvv44Oo7frd4+G+TQ==",
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-reference/0.31.0/20334725df367c99549e5ab39206b093ea3c3446d6a1b6f3312fd40b86db524b",
+      "integrity": "sha512-PsOfr9PSL+Mw44MbfkhmIUuF57Xd1L4sTNvmuPT+KW3ch8BGFAyAToeuO5dVU6LbQ0U75R5CoGru41HIiviA+w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "=7.18.3",
-        "@swagger-api/apidom-ast": "^0.30.0",
-        "@swagger-api/apidom-core": "^0.30.0",
-        "@swagger-api/apidom-json-pointer": "^0.30.0",
-        "@swagger-api/apidom-ns-asyncapi-2": "^0.30.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.30.0",
-        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^0.30.1",
-        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^0.30.1",
-        "@swagger-api/apidom-parser-adapter-json": "^0.30.1",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^0.30.1",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^0.30.1",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.30.1",
+        "@swagger-api/apidom-ast": "^0.31.0",
+        "@swagger-api/apidom-core": "^0.31.0",
+        "@swagger-api/apidom-json-pointer": "^0.31.0",
+        "@swagger-api/apidom-ns-asyncapi-2": "^0.31.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-json": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.31.0",
         "@types/ramda": "=0.28.14",
         "axios": "=0.27.2",
         "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.1.0",
+        "ramda-adjunct": "=3.2.0",
         "stampit": "=4.3.2"
       }
     },
@@ -6577,13 +6624,19 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001296",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001296.tgz",
-      "integrity": "sha512-WfrtPEoNSoeATDlf4y3QvkwiELl9GyPLISV5GejTbbQRtQx4LhsXmc9IQ6XCL2d7UxCyEzToEZNMeqR79OUw8Q==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "version": "1.0.30001358",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001358.tgz",
+      "integrity": "sha512-hvp8PSRymk85R20bsDra7ZTCpSVGN/PAz9pSAjPSjKC+rNmnUk5vCRgJwiTT/O4feQ/yu/drvZYpKxxhbFuChw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",
@@ -16701,9 +16754,9 @@
       }
     },
     "node_modules/ramda-adjunct": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.1.0.tgz",
-      "integrity": "sha512-jMGcsyYmo4d1hrNdAau3wonLyQzAz+J1RQj1WL7J7SqZ5ziEN5C9LjjUYfMvBP9w4ZYAS4bVeRIkEWucqdlRHw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.2.0.tgz",
+      "integrity": "sha512-lfpDz3VX5vS5YE1pgLYHOqWiX8+0gKnCDbm/DpIYpMsWx90g2I5c5/SfgUojjt3P4GidRauJrPc5OY2aoeLrWw==",
       "engines": {
         "node": ">=0.10.3"
       },
@@ -24218,66 +24271,66 @@
       }
     },
     "@swagger-api/apidom-ast": {
-      "version": "0.30.0",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-ast/0.30.0/3dd8e5d23ce5d03e83244e9a1d94c5d1c3424a4dc8048ec6e08e7e591463f6f3",
-      "integrity": "sha512-24whuAT2rGfsU3PMx7eFENxYsYdTvQSVt/CtS/VD7nbyXvxsQLOe2Bl4gzRYRxKMhQdA5CT4pWehTXOEZZu81w==",
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-ast/0.31.0/91014600f569882533b550335b346112800199e9601839f7988146178dce841a",
+      "integrity": "sha512-1JFHmmq4kvcQYrr8u/8nLptHH+pImgpyymJnMEHqcnM/vczGBhfCMHdXan2IPnIcTF8ZN0q2i5Cm8hnpx+n/pg==",
       "requires": {
         "@babel/runtime-corejs3": "=7.18.3",
         "@types/ramda": "=0.28.14",
         "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.1.0",
+        "ramda-adjunct": "=3.2.0",
         "stampit": "=4.3.2",
         "unraw": "=2.0.1"
       }
     },
     "@swagger-api/apidom-core": {
-      "version": "0.30.0",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-core/0.30.0/17b0a4266e1603b869699fadc52076eec55eab5890e214b5e041737e802f039d",
-      "integrity": "sha512-jBcYXyudspcjoheNGd9YBAXedMbywJVCyL7GFYV/h4KurNbpZ2a5A1woL+VvEjvwnnB5CmEa7wPE/qAJYYjMsg==",
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-core/0.31.0/376e658dcda4ddc9a53a46e08bd8512ee6eb35145bfa10920d061dcec2218942",
+      "integrity": "sha512-j1+SRvCFfbz2ZHTz/cHV7Wy4NoHPlb0n+7ZyJ8YCk16or606wvti/gYLLPL5I+joRxx+/CcDfo3/PMQCWylC8g==",
       "requires": {
         "@babel/runtime-corejs3": "=7.18.3",
-        "@swagger-api/apidom-ast": "^0.30.0",
+        "@swagger-api/apidom-ast": "^0.31.0",
         "@types/ramda": "=0.28.14",
         "minim": "=0.23.8",
         "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.1.0",
+        "ramda-adjunct": "=3.2.0",
         "short-unique-id": "=4.4.4",
         "stampit": "=4.3.2"
       }
     },
     "@swagger-api/apidom-json-pointer": {
-      "version": "0.30.0",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-json-pointer/0.30.0/1da05381f7b3a728561825c953e62abb2004fe27e27d95a8f6c2ff6017327348",
-      "integrity": "sha512-sBkyYUaMaYEGITdJ9TLahcHsvz95e7s9HLOjkTT2ESVf27feVE5MgtyFld9AT3tENSXEDFiIXbEWGXpcSgZkIg==",
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-json-pointer/0.31.0/4aaaf960e5408f1931a43057c1f146078aebc791ec9a11113b1b445d06ddca43",
+      "integrity": "sha512-gezS6frzKMaWQ3NR5Vhzrz/GfEsWDE7mhocQZUBF4a0U/2+qwv7i29HF0KEwKzYqMCMXm7E1eSLD2pVyD7tUrw==",
       "requires": {
         "@babel/runtime-corejs3": "=7.18.3",
-        "@swagger-api/apidom-core": "^0.30.0",
+        "@swagger-api/apidom-core": "^0.31.0",
         "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.1.0"
+        "ramda-adjunct": "=3.2.0"
       }
     },
     "@swagger-api/apidom-ls": {
-      "version": "0.30.1",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-ls/0.30.1/1c43cd86517f8ced16d1ceb9866e13383be332af864efe14071d856687bed9df",
-      "integrity": "sha512-hfXNb9RkVU08NgOB75YDrH+YNSGFwa0iSjUGH5Brh3YEIv8+OCwH3vq4i8XTCFvfAfwfFN/b8dUTylBMApReuA==",
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-ls/0.31.0/62088bf6672ecf503e406d7bb685e105ba34f13d12526d345858133a475afa5a",
+      "integrity": "sha512-/EELWyImf3rndJTXxj/AXBn2oMuuyK+w7M1mLM/1ohtAPONXkVN7LxZtbHLONxtYAETmzrtnhusw5QJ6GgS57Q==",
       "requires": {
         "@babel/runtime-corejs3": "=7.18.3",
-        "@swagger-api/apidom-core": "^0.30.0",
-        "@swagger-api/apidom-json-pointer": "^0.30.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.30.0",
-        "@swagger-api/apidom-parser": "^0.30.0",
-        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^0.30.1",
-        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^0.30.1",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^0.30.1",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^0.30.1",
-        "@swagger-api/apidom-reference": "^0.30.1",
+        "@swagger-api/apidom-core": "^0.31.0",
+        "@swagger-api/apidom-json-pointer": "^0.31.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.31.0",
+        "@swagger-api/apidom-parser": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^0.31.0",
+        "@swagger-api/apidom-reference": "^0.31.0",
         "@types/ramda": "=0.28.14",
         "ajv": "^8.6.3",
         "ajv-errors": "^3.0.0",
         "ajv-formats": "^2.1.1",
         "json-source-map": "^0.6.1",
         "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.1.0",
+        "ramda-adjunct": "=3.2.0",
         "stampit": "=4.3.2",
         "vscode-languageserver-protocol": "^3.16.0",
         "vscode-languageserver-textdocument": "^1.0.1",
@@ -24309,84 +24362,126 @@
         }
       }
     },
-    "@swagger-api/apidom-ns-asyncapi-2": {
-      "version": "0.30.0",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-ns-asyncapi-2/0.30.0/577b1e902206454583b3e11803dca79ff70ded2613d2b48f69ed5712f3008180",
-      "integrity": "sha512-37dIo579lsrO0r4axMUHSNcEz+ScSw3MWTohL1wyQqxBCxeslXytgYtqccypKr8zuiYrUNopIxk4HznUTQfKpQ==",
+    "@swagger-api/apidom-ns-api-design-systems": {
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-ns-api-design-systems/0.31.0/83a6bf465977aacff7d92ae522fd804d79994e20f8ce80c6fe07464b4baa4515",
+      "integrity": "sha512-QVUlL4cQGcvP9I193PwRxS7lv8ZLDHkTsVchRpW0Mje/ueYAlpRyEvrcSiEkLR+h2Ly+ol37GUoebhMgIoyAbg==",
       "requires": {
         "@babel/runtime-corejs3": "=7.18.3",
-        "@swagger-api/apidom-core": "^0.30.0",
+        "@swagger-api/apidom-core": "^0.31.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.31.0",
         "@types/ramda": "=0.28.14",
         "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.1.0",
+        "ramda-adjunct": "=3.2.0",
+        "stampit": "=4.3.2"
+      }
+    },
+    "@swagger-api/apidom-ns-asyncapi-2": {
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-ns-asyncapi-2/0.31.0/fde7a31e3008b24cb403680cc98384ef82dede661a142f9ef60ae898da75f5a3",
+      "integrity": "sha512-rAFfy9H8ogqNHgFajkPtMTtoAcWNg70voL2btns3godNQgclPJyhpO1vDhM1JCYhFSuyxZEn8EvUMQGw1qGxVQ==",
+      "requires": {
+        "@babel/runtime-corejs3": "=7.18.3",
+        "@swagger-api/apidom-core": "^0.31.0",
+        "@types/ramda": "=0.28.14",
+        "ramda": "=0.28.0",
+        "ramda-adjunct": "=3.2.0",
         "stampit": "=4.3.2"
       }
     },
     "@swagger-api/apidom-ns-openapi-3-1": {
-      "version": "0.30.0",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-ns-openapi-3-1/0.30.0/1acbd06d1e21ad022b7e0645758bdceadc54220292b8fd271e8ee7e3cc37f747",
-      "integrity": "sha512-UjghFpee1TLSsDD/hybmy2ix+ZSfxeklrlpIH6CzIM6ytUOA7Fpni787mhA8jD88qkn4Acuj/mxfsAxh9vG1dA==",
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-ns-openapi-3-1/0.31.0/6430ca6b22c2305ab3f6fdda29d2a786bf6fe45ad2a0437b5454290c635afa4d",
+      "integrity": "sha512-3iXCLqTW/mrlgG9/CyMvHvng8qChNKREFgaXpraZVsaoGiM3jDvkLmpVAwJT8IrLTeYrbRBKUbZOPzuIrJQz7A==",
       "requires": {
         "@babel/runtime-corejs3": "=7.18.3",
-        "@swagger-api/apidom-core": "^0.30.0",
+        "@swagger-api/apidom-core": "^0.31.0",
         "@types/ramda": "=0.28.14",
         "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.1.0",
+        "ramda-adjunct": "=3.2.0",
         "stampit": "=4.3.2"
       }
     },
     "@swagger-api/apidom-parser": {
-      "version": "0.30.0",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser/0.30.0/b5c874b9bfa95801a41406cbeced6079600b473ef1d2aa75964623220a73d71d",
-      "integrity": "sha512-tzslUdcfBvN/M7s6yI1wcY/UZQ22G7I1k7SRJMsyXNMDVsyGde4c7rINCL3d+w2UXjWm9yQ8p5U3TG6xrhhnXA==",
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser/0.31.0/94b17e0f6f64284ba79bd85e623133d9c02dc14834adc8c51d7d42afb4f2a1cd",
+      "integrity": "sha512-eWgnLi/bVpR47ItFisbKEzjD9qPoxCIlzGQYISmqpEPy5b7qzhYgTJdct1U3DPzadU8ifOwmnSYFXu+J0WwLLQ==",
       "requires": {
         "@babel/runtime-corejs3": "=7.18.3",
-        "@swagger-api/apidom-core": "^0.30.0",
+        "@swagger-api/apidom-core": "^0.31.0",
         "@types/ramda": "=0.28.14",
         "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.1.0",
+        "ramda-adjunct": "=3.2.0",
         "stampit": "=4.3.2"
       }
     },
-    "@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
-      "version": "0.30.1",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser-adapter-asyncapi-json-2/0.30.1/c4bd647b83398a8deae29d17288f7bcb0cfcc46f87f88a4bc258705c3b4d085d",
-      "integrity": "sha512-d/PVIWHpiEjiaQtfVAmsxrLBd8a660KoaSfO8xoLwexcmMqeerVRe3QMAITulEGOHyJ32p7+E66ZSdyYI9VadA==",
+    "@swagger-api/apidom-parser-adapter-api-design-systems-json": {
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser-adapter-api-design-systems-json/0.31.0/e271750e5464060c3bfdeb98c2d0b143ab5e0218803341def74e9803afbbbf17",
+      "integrity": "sha512-ipLhNBGnZsb9guqaMAi9dBxpj7oeRSS7Ac72+ZkIIabUfQzg6i6Tw84SBsfl/FhAJ7rknRdMVt42MrOYHnjafQ==",
       "requires": {
         "@babel/runtime-corejs3": "=7.18.3",
-        "@swagger-api/apidom-core": "^0.30.0",
-        "@swagger-api/apidom-ns-asyncapi-2": "^0.30.0",
-        "@swagger-api/apidom-parser-adapter-json": "^0.30.1",
+        "@swagger-api/apidom-core": "^0.31.0",
+        "@swagger-api/apidom-ns-api-design-systems": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-json": "^0.31.0",
         "@types/ramda": "=0.28.14",
         "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.1.0"
+        "ramda-adjunct": "=3.2.0"
+      }
+    },
+    "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/0.31.0/fb20c0972689177a371eee43c6ef23500755aeb853ee1237d09d29a19df6465e",
+      "integrity": "sha512-ynJ1QrvNouCIUNkylEZCfXLbyaTElkqFHddzyOr9EBZsT5qsFqPYhDXrwst//SXEKZ8MhXlZR+w8Bxl0M91sjA==",
+      "requires": {
+        "@babel/runtime-corejs3": "=7.18.3",
+        "@swagger-api/apidom-core": "^0.31.0",
+        "@swagger-api/apidom-ns-api-design-systems": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.31.0",
+        "@types/ramda": "=0.28.14",
+        "ramda": "=0.28.0",
+        "ramda-adjunct": "=3.2.0"
+      }
+    },
+    "@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser-adapter-asyncapi-json-2/0.31.0/b84de0485604b06427098e81271f26396121e2c229b2331966639c15872dcea3",
+      "integrity": "sha512-ZspmO6oXeREnKcqPRGOJw/kXnXHbj3V1Kc5737advg+pU9brTcGDyk41T/HLx0j2VQNfEFi2zIpi57HrEpKY9w==",
+      "requires": {
+        "@babel/runtime-corejs3": "=7.18.3",
+        "@swagger-api/apidom-core": "^0.31.0",
+        "@swagger-api/apidom-ns-asyncapi-2": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-json": "^0.31.0",
+        "@types/ramda": "=0.28.14",
+        "ramda": "=0.28.0",
+        "ramda-adjunct": "=3.2.0"
       }
     },
     "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
-      "version": "0.30.1",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/0.30.1/b351e09b63fff222463f49c7a38ac688eb9fbc7e431e1f5f5775d0c6ccb65b21",
-      "integrity": "sha512-j0cnaQrlFGd9xY+SYrIC9BG+tw+Q6N+YfYEZx2kFzZqEW5/L0pmxesr37pPLSiZgFsiOU+GfrREvkbtwVsi7kA==",
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/0.31.0/c7cb9eb0011d3912076b18aac14deba5311d0ae0abfcbd6ba2fde08332f39d0c",
+      "integrity": "sha512-6FgNPyaPfQmAmgn9vBYTpczqMRmQPsUczQSNT0Iv8KbsbTDPnaCyCzyDnvyhuxYQwEv/FXqyTxBKj6RGrKUvbQ==",
       "requires": {
         "@babel/runtime-corejs3": "=7.18.3",
-        "@swagger-api/apidom-core": "^0.30.0",
-        "@swagger-api/apidom-ns-asyncapi-2": "^0.30.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.30.1",
+        "@swagger-api/apidom-core": "^0.31.0",
+        "@swagger-api/apidom-ns-asyncapi-2": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.31.0",
         "@types/ramda": "=0.28.14",
         "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.1.0"
+        "ramda-adjunct": "=3.2.0"
       }
     },
     "@swagger-api/apidom-parser-adapter-json": {
-      "version": "0.30.1",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser-adapter-json/0.30.1/3c43795a4c174a73167b42880226e9a7ca58900810b822d07c36704fbf53c2e2",
-      "integrity": "sha512-5D2sp+yRiwGIop9Lza9u+3gAxuRpJBBylPIiNDB9T0dTAI/bKdVnIFcRjxIoMSNpPo1gSoAj5mCgOc2V1GaUWA==",
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser-adapter-json/0.31.0/fa51dd637c08f40056fd2ec7b8003170ed6dd3c249e23067f5301e09cd3d32e2",
+      "integrity": "sha512-tgwBMhDH4DQfP8Z5nlXyPV1bjDWihECN3iVKxeVBfqib+fMmaZ296llIFV3mu11qxy3JZGpT/mCgt6UmN72Qjg==",
       "requires": {
         "@babel/runtime-corejs3": "=7.18.3",
-        "@swagger-api/apidom-ast": "^0.30.0",
-        "@swagger-api/apidom-core": "^0.30.0",
+        "@swagger-api/apidom-ast": "^0.31.0",
+        "@swagger-api/apidom-core": "^0.31.0",
         "@types/ramda": "=0.28.14",
         "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.1.0",
+        "ramda-adjunct": "=3.2.0",
         "stampit": "=4.3.2",
         "tree-sitter": "=0.20.0",
         "tree-sitter-json": "=0.20.0",
@@ -24394,44 +24489,44 @@
       }
     },
     "@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
-      "version": "0.30.1",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser-adapter-openapi-json-3-1/0.30.1/9717189134381d5b896ad77de00c9967a61b423d2b9431a43468d18effae09a5",
-      "integrity": "sha512-TnO4CubZzmsIxGA+N5b3bFY5WMqIM/UK6xvxDKnixTGwkMe6o4Qb3W6TRiKX6fDFi+B2vGLeLRruJgGTznN4aA==",
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser-adapter-openapi-json-3-1/0.31.0/6f380cef75a3e7c10d6718c1ea07bf4e705122c1538a8b0ea23b771eb42f9e86",
+      "integrity": "sha512-QIcj8Ov+JeHMsMy/5VjbjczdWOeHViSSTZAGKrojjPTOddsQRk8N8pNW4BWPIpi7fP2OK/FrrYVY6m6q3F6vbg==",
       "requires": {
         "@babel/runtime-corejs3": "=7.18.3",
-        "@swagger-api/apidom-core": "^0.30.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.30.0",
-        "@swagger-api/apidom-parser-adapter-json": "^0.30.1",
+        "@swagger-api/apidom-core": "^0.31.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-json": "^0.31.0",
         "@types/ramda": "=0.28.14",
         "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.1.0"
+        "ramda-adjunct": "=3.2.0"
       }
     },
     "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
-      "version": "0.30.1",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/0.30.1/a82bad1991cb1020b21b93c3b8d5fd565a97ebb2b54b016dae4bdca6c1fefae7",
-      "integrity": "sha512-yJgK8AXk4RjTi6+z2pamTpVFbubU+cbUH6OTQLmWXg8AMV90ikTihMx2RCCgXhlQybEgMHsk/8DWPDw02PvJxQ==",
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/0.31.0/69ca96f53efcc491bbd791d220988bafa37ae2d39e63afcc4fd23e1c9ff24405",
+      "integrity": "sha512-cfzGxyg9MsbEBXFcjgMy612JKC9+fXiWK03B2zjKuw2J1uoqG20Ap5XJElT89N4ZgNrlBXV/M8JC4+Y6sV/6vw==",
       "requires": {
         "@babel/runtime-corejs3": "=7.18.3",
-        "@swagger-api/apidom-core": "^0.30.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.30.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.30.1",
+        "@swagger-api/apidom-core": "^0.31.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.31.0",
         "@types/ramda": "=0.28.14",
         "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.1.0"
+        "ramda-adjunct": "=3.2.0"
       }
     },
     "@swagger-api/apidom-parser-adapter-yaml-1-2": {
-      "version": "0.30.1",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser-adapter-yaml-1-2/0.30.1/b6c0869306639b0db080bd80c504b7a77ee2a8643c2d6e6539dc2a034b53078c",
-      "integrity": "sha512-pZSlpNIVOU/SmQ6rtlZ5bU6yPPs7UAWnL0Xc6lcCE3XD9Ecb9lRfdteFfR36vP26Xv+C6I7k5EC4EkcP1tLhaA==",
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-parser-adapter-yaml-1-2/0.31.0/f2c8d5d234d79ede6268531f23ea5e67e86b308f44531f7a6bc9b3420c5485a1",
+      "integrity": "sha512-/bBdRBzse7zZrVzfSRYctQX47LQhy+Sbh+tHqbH3H5JCgqAVaLTk9hukSrBN60tzstpUJW97OdZtT5OHiYbDRg==",
       "requires": {
         "@babel/runtime-corejs3": "=7.18.3",
-        "@swagger-api/apidom-ast": "^0.30.0",
-        "@swagger-api/apidom-core": "^0.30.0",
+        "@swagger-api/apidom-ast": "^0.31.0",
+        "@swagger-api/apidom-core": "^0.31.0",
         "@types/ramda": "=0.28.14",
         "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.1.0",
+        "ramda-adjunct": "=3.2.0",
         "stampit": "=4.3.2",
         "tree-sitter": "=0.20.0",
         "tree-sitter-yaml": "=0.5.0",
@@ -24439,26 +24534,28 @@
       }
     },
     "@swagger-api/apidom-reference": {
-      "version": "0.30.1",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-reference/0.30.1/39aa622eeacb775093d06449daba43d2aee67ed5893b6c96688d2995ae35ab37",
-      "integrity": "sha512-VPwruNTirFifge8S4h2oYWrRaSCijMHSuEYOGa3jyF7vWJDfOAWZwIRHvS3Qon0udv0fFWvv44Oo7frd4+G+TQ==",
+      "version": "0.31.0",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-reference/0.31.0/20334725df367c99549e5ab39206b093ea3c3446d6a1b6f3312fd40b86db524b",
+      "integrity": "sha512-PsOfr9PSL+Mw44MbfkhmIUuF57Xd1L4sTNvmuPT+KW3ch8BGFAyAToeuO5dVU6LbQ0U75R5CoGru41HIiviA+w==",
       "requires": {
         "@babel/runtime-corejs3": "=7.18.3",
-        "@swagger-api/apidom-ast": "^0.30.0",
-        "@swagger-api/apidom-core": "^0.30.0",
-        "@swagger-api/apidom-json-pointer": "^0.30.0",
-        "@swagger-api/apidom-ns-asyncapi-2": "^0.30.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.30.0",
-        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^0.30.1",
-        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^0.30.1",
-        "@swagger-api/apidom-parser-adapter-json": "^0.30.1",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^0.30.1",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^0.30.1",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.30.1",
+        "@swagger-api/apidom-ast": "^0.31.0",
+        "@swagger-api/apidom-core": "^0.31.0",
+        "@swagger-api/apidom-json-pointer": "^0.31.0",
+        "@swagger-api/apidom-ns-asyncapi-2": "^0.31.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-json": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^0.31.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.31.0",
         "@types/ramda": "=0.28.14",
         "axios": "=0.27.2",
         "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.1.0",
+        "ramda-adjunct": "=3.2.0",
         "stampit": "=4.3.2"
       }
     },
@@ -26393,9 +26490,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001296",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001296.tgz",
-      "integrity": "sha512-WfrtPEoNSoeATDlf4y3QvkwiELl9GyPLISV5GejTbbQRtQx4LhsXmc9IQ6XCL2d7UxCyEzToEZNMeqR79OUw8Q=="
+      "version": "1.0.30001358",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001358.tgz",
+      "integrity": "sha512-hvp8PSRymk85R20bsDra7ZTCpSVGN/PAz9pSAjPSjKC+rNmnUk5vCRgJwiTT/O4feQ/yu/drvZYpKxxhbFuChw=="
     },
     "case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",
@@ -33860,9 +33957,9 @@
       "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA=="
     },
     "ramda-adjunct": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.1.0.tgz",
-      "integrity": "sha512-jMGcsyYmo4d1hrNdAau3wonLyQzAz+J1RQj1WL7J7SqZ5ziEN5C9LjjUYfMvBP9w4ZYAS4bVeRIkEWucqdlRHw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.2.0.tgz",
+      "integrity": "sha512-lfpDz3VX5vS5YE1pgLYHOqWiX8+0gKnCDbm/DpIYpMsWx90g2I5c5/SfgUojjt3P4GidRauJrPc5OY2aoeLrWw==",
       "requires": {}
     },
     "randexp": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lint": "eslint . --ext .jsx,.js",
     "lint:fix": "eslint . --ext .jsx,.js --fix",
     "clean": "rimraf ./build ./dist",
-    "link:apidom": "npm link @swagger-api/apidom-ast @swagger-api/apidom-core @swagger-api/apidom-json-path @swagger-api/apidom-json-pointer @swagger-api/apidom-parser-adapter-json @swagger-api/apidom-ns-asyncapi-2 @swagger-api/apidom-parser-adapter-yaml-1-2 @swagger-api/apidom-parser-adapter-asyncapi-yaml-2 @swagger-api/apidom-parser-adapter-openapi-yaml-3-1 @swagger-api/apidom-parser @swagger-api/apidom-parser-adapter-asyncapi-json-2 @swagger-api/apidom-ls @swagger-api/apidom-ns-openapi-3-1 @swagger-api/apidom-reference @swagger-api/apidom-parser-adapter-openapi-json-3-1",
+    "link:apidom": "npm link @swagger-api/apidom-ast @swagger-api/apidom-core @swagger-api/apidom-json-path @swagger-api/apidom-json-pointer @swagger-api/apidom-ls @swagger-api/apidom-ns-api-design-systems @swagger-api/apidom-ns-asyncapi-2 @swagger-api/apidom-ns-openapi-3-1 @swagger-api/apidom-parser-adapter-api-design-systems-json @swagger-api/apidom-parser-adapter-api-design-systems-yaml @swagger-api/apidom-parser-adapter-asyncapi-json-2 @swagger-api/apidom-parser-adapter-asyncapi-yaml-2 @swagger-api/apidom-parser-adapter-json @swagger-api/apidom-parser-adapter-openapi-json-3-1 @swagger-api/apidom-parser-adapter-openapi-yaml-3-1 @swagger-api/apidom-parser-adapter-yaml-1-2 @swagger-api/apidom-parser @swagger-api/apidom-reference",
     "link:apidom-ls": "npm link @swagger-api/apidom-ls"
   },
   "dependencies": {
@@ -62,7 +62,7 @@
     "@emotion/styled": "^11.9.3",
     "@mui/material": "^5.8.4",
     "@primer/octicons-react": "^17.3.0",
-    "@swagger-api/apidom-ls": "^0.30.1",
+    "@swagger-api/apidom-ls": "^0.31.0",
     "axios": "^0.27.2",
     "deepmerge": "^4.2.2",
     "file-dialog": "^0.0.8",

--- a/src/plugins/editor-monaco/utils/monaco-action-apidom-deref.js
+++ b/src/plugins/editor-monaco/utils/monaco-action-apidom-deref.js
@@ -3,7 +3,11 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import YAML from 'js-yaml';
 
 export async function dereference(editor) {
-  const apidomContext = {};
+  const apidomContext = {
+    defaultLanguageContent: {
+      namespace: 'asyncapi',
+    },
+  };
   const languageService = getLanguageService(apidomContext);
 
   try {

--- a/src/plugins/editor-monaco/workers/apidom/ApiDOMWorker.js
+++ b/src/plugins/editor-monaco/workers/apidom/ApiDOMWorker.js
@@ -8,6 +8,9 @@ export class ApiDOMWorker {
     completionProviders: [],
     performanceLogs: false,
     logLevel: apidomLS.LogLevel.WARN,
+    defaultLanguageContent: {
+      namespace: 'asyncapi',
+    },
   };
 
   constructor(ctx, createData) {

--- a/src/plugins/editor-monaco/workers/apidom/adapters/SemanticTokensAdapter.js
+++ b/src/plugins/editor-monaco/workers/apidom/adapters/SemanticTokensAdapter.js
@@ -37,6 +37,9 @@ export default class SemanticTokensAdapter {
       return getLanguageService({
         performanceLogs: false,
         logLevel: LogLevel.WARN,
+        defaultLanguageContent: {
+          namespace: 'asyncapi',
+        },
       }).getSemanticTokensLegend();
     } catch {
       return this.#legendError;

--- a/src/plugins/topbar/actions/save-as-json-or-yaml/index.js
+++ b/src/plugins/topbar/actions/save-as-json-or-yaml/index.js
@@ -72,7 +72,11 @@ export const saveAsJsonResolved = () => async (system) => {
         'Save as JSON is not currently possible because Swagger-Editor was not able to parse your API definiton.',
     };
   }
-  const apidomContext = {};
+  const apidomContext = {
+    defaultLanguageContent: {
+      namespace: 'asyncapi',
+    },
+  };
   const languageService = getLanguageService(apidomContext); // use apidom metadata
 
   try {
@@ -119,7 +123,11 @@ export const saveAsYamlResolved = () => async (system) => {
     };
   }
 
-  const apidomContext = {};
+  const apidomContext = {
+    defaultLanguageContent: {
+      namespace: 'asyncapi',
+    },
+  };
   const languageService = getLanguageService(apidomContext); // use apidom metadata
 
   try {


### PR DESCRIPTION
To maintain backward compatible behavior,
defaultLanguageContent context option for language
service has been introduced with following value:

```
defaultLanguageContent: {
  namespace: 'asyncapi',
}
```

ApiDOM@0.31.0 comes with support for defaultLanguageContent
language service option.

Refs https://github.com/swagger-api/apidom/issues/1582
