### PR TITLE
fix(cypress): enable validation-pane and disable monaco spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "analyze": "source-map-explorer 'dist/umd/swagger-editor.js'",
     "test": "react-scripts test",
     "cy:dev": "start-server-and-test cy:dev:server http://localhost:3003 cy:dev:open",
-    "cy:dev:open": "CYPRESS_BASE_URL=http://localhost:3003 cypress open",
+    "cy:dev:open": "CYPRESS_BASE_URL=http://localhost:3003 cypress open --e2e",
     "cy:dev:server": "cross-env PORT=3003 BROWSER=none ENABLE_PROGRESS_PLUGIN=false react-scripts start",
     "cy:ci": "start-server-and-test build:app:serve http://localhost:3050 cy:run:chrome",
     "cy:run:chrome": "cypress run --browser chrome",

--- a/test/cypress/integration/monaco.spec.js
+++ b/test/cypress/integration/monaco.spec.js
@@ -8,7 +8,7 @@
 
 const selectAllKeys = ['darwin', 'linux'].includes(Cypress.platform) ? '{cmd}a' : '{ctrl}a';
 
-describe('Monaco Editor with Parser', () => {
+describe.skip('Monaco Editor with Parser', () => {
   beforeEach(() => {
     cy.window().then((contentWindow) => {
       // console.log already globally stubbed in cy support/commands

--- a/test/cypress/integration/plugin.validation-pane.spec.js
+++ b/test/cypress/integration/plugin.validation-pane.spec.js
@@ -1,7 +1,8 @@
-describe.skip('Monaco Editor with Validation Pane', () => {
+describe('Monaco Editor with Validation Pane', () => {
   beforeEach(() => {
     cy.prepareAsyncAPI();
-    const moveToPosition = `{rightArrow}{rightArrow}`;
+    // move down to line 2, column 3
+    const moveToPosition = `{downArrow}{rightArrow}{rightArrow}`;
     // introduce a typo error
     cy.get('.monaco-editor textarea:first').click().focused().type(`${moveToPosition}Q`);
   });
@@ -26,11 +27,13 @@ describe.skip('Monaco Editor with Validation Pane', () => {
     cy.get('.swagger-editor__validation-table > thead > tr > :nth-child(2)')
       .contains('description', { matchCase: false })
       .should('be.visible');
+    // reflects line number from moveToPosition for validation error
     cy.get('.swagger-editor__validation-table > tbody > :nth-child(1) > :nth-child(1) > div')
-      .contains('1')
+      .contains('2')
       .should('be.visible');
+    // validation error message is parser specific
     cy.get('.swagger-editor__validation-table > tbody > :nth-child(1) > :nth-child(2) > div')
-      .contains('should always have')
+      .contains('should NOT have')
       .should('be.visible');
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

* Fix and re-enable Cypress `plugin.validation-pane.spec`. With the fix, parser should now always know to parse against the AsyncApi spec.
* Disable Cypress `monaco.spec`. ref #3184 
* Update `cypress open` command with `--e2e` flag. Since we do not currently use Cypress for component testing, this is a developer convenience, though still need to select the browser to use in Cypress UI.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

* Improve Cypress reliability for `plugin.validation-pane.spec`
* Resolve CI errors since the Cypress@10 update

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

local cypress runs

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
