### PR TITLE
fix(editor): should clear asyncapi parser markers on valid parse

### DIFF
--- a/src/plugins/editor-preview-asyncapi/components/AsyncAPIEditorPreviewPane.jsx
+++ b/src/plugins/editor-preview-asyncapi/components/AsyncAPIEditorPreviewPane.jsx
@@ -86,7 +86,7 @@ const AsyncAPIEditorPreviewPane = ({
             if (!doc) {
               setIsValid(false);
             } else {
-              // clear reducer state
+              // if valid, should always clear reducer state
               asyncapiActions.updateAsyncApiParserMarkers([]);
               setIsValid(true);
               try {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

On valid AsyncApi parse, always also clear the error state.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

> what we see is that when we create a parser issue (ie. removing a $ref), the error is correctly added to the stack

> but when we resolve that ref (ie. pressing undo), the error does not get removed from the stack. my theory is that the validator is running again but as there is no error stack update code in the successful parse part of the promise, the error does not get cleared until a future event:

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

local

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
