### PR TITLE
feat: jumpToPath plugin with Monaco

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,7 @@ import EditorContentOriginPlugin from './plugins/editor-content-origin/index.js'
 import EditorContentTypePlugin from './plugins/editor-content-type/index.js';
 import EditorContentPersistencePlugin from './plugins/editor-content-persistence/index.js';
 import EditorContentFixturesPlugin from './plugins/editor-content-fixtures/index.js';
+import EditorContentJumpFromPathToLinePlugin from './plugins/editor-content-jump-from-path-to-line/index.js';
 
 const SafeRenderPlugin = (system) =>
   SwaggerUI.plugins.SafeRender({
@@ -65,6 +66,7 @@ SwaggerEditor.plugins = {
   EditorContentType: EditorContentTypePlugin,
   EditorContentPersistence: EditorContentPersistencePlugin,
   EditorContentFixtures: EditorContentFixturesPlugin,
+  EditorContentJumpFromPathToLine: EditorContentJumpFromPathToLinePlugin,
   EditorPreview: EditorPreviewPlugin,
   EditorPreviewSwaggerUI: EditorPreviewSwaggerUIPlugin,
   EditorPreviewAsyncAPI: EditorPreviewAsyncAPIPlugin,
@@ -85,6 +87,7 @@ SwaggerEditor.presets = {
     EditorContentTypePlugin,
     EditorContentPersistencePlugin,
     EditorContentFixturesPlugin,
+    EditorContentJumpFromPathToLinePlugin,
     EditorPreviewPlugin,
     EditorPreviewSwaggerUIPlugin,
     EditorPreviewAsyncAPIPlugin,
@@ -106,6 +109,7 @@ SwaggerEditor.presets = {
     EditorContentTypePlugin,
     EditorContentPersistencePlugin,
     EditorContentFixturesPlugin,
+    EditorContentJumpFromPathToLinePlugin,
     EditorPreviewPlugin,
     EditorPreviewSwaggerUIPlugin,
     EditorPreviewAsyncAPIPlugin,

--- a/src/plugins/editor-content-jump-from-path-to-line/components/JumpFromPathToLine.jsx
+++ b/src/plugins/editor-content-jump-from-path-to-line/components/JumpFromPathToLine.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+
+import JumpIcon from './jump-icon.svg';
+
+/**
+ * JumpToPath is a legacy name that is already built into SwaggerUI
+ * 1. onHover of SwaggerUI operation or model, render svg icon
+ * 2. onClick of svg icon => jump to line in editorContent
+ */
+
+const JumpFromPathToLine = ({
+  editorActions,
+  editorSelectors,
+  path,
+  specPath,
+  content,
+  showButton,
+}) => {
+  const handleJumpToEditorLine = (e) => {
+    e.stopPropagation();
+    const jumpPath = editorSelectors.bestJumpPath({ path, specPath });
+    // `apidom-ls` will expect `jumpPath` to be a String instead of legacy Array, e.g. '/components/schemas/Category/properties/id'
+    // `Editor` will handle the rest of workflow
+    editorActions.setRequestJumpToEditorMarker({ jsonPointer: jumpPath });
+  };
+
+  const defaultJumpButton = (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={handleJumpToEditorLine}
+      onKeyPress={handleJumpToEditorLine}
+    >
+      <img src={JumpIcon} className="view-line-link" title="Jump to definition" alt="" />
+    </div>
+  );
+
+  if (content) {
+    // if we were given content to render, wrap it
+    return (
+      <span
+        role="button"
+        tabIndex={0}
+        onClick={handleJumpToEditorLine}
+        onKeyPress={handleJumpToEditorLine}
+      >
+        {showButton ? { defaultJumpButton } : null}
+        {content}
+      </span>
+    );
+  }
+  return <div>{defaultJumpButton}</div>;
+};
+
+JumpFromPathToLine.propTypes = {
+  editorActions: PropTypes.oneOfType([PropTypes.object]).isRequired,
+  editorSelectors: PropTypes.oneOfType([PropTypes.object]).isRequired, // TODO: make this a shape
+  path: PropTypes.oneOfType([PropTypes.array, PropTypes.string, ImmutablePropTypes.list]),
+  specPath: PropTypes.oneOfType([PropTypes.array, ImmutablePropTypes.list]), // the location within the spec. used as a fallback if `path` doesn't exist
+  content: PropTypes.element,
+  showButton: PropTypes.bool,
+};
+
+JumpFromPathToLine.defaultProps = {
+  path: [],
+  specPath: [],
+  content: null,
+  showButton: false,
+};
+
+export default JumpFromPathToLine;

--- a/src/plugins/editor-content-jump-from-path-to-line/components/jump-icon.svg
+++ b/src/plugins/editor-content-jump-from-path-to-line/components/jump-icon.svg
@@ -1,0 +1,3 @@
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+<path d="M19 7v4H5.83l3.58-3.59L8 6l-6 6 6 6 1.41-1.41L5.83 13H21V7z"/>
+</svg>

--- a/src/plugins/editor-content-jump-from-path-to-line/index.js
+++ b/src/plugins/editor-content-jump-from-path-to-line/index.js
@@ -1,0 +1,17 @@
+import JumpFromPathToLine from './components/JumpFromPathToLine.jsx';
+import { bestJumpPath } from './selectors.js';
+
+const EditorContentJumpFromPathToLinePlugin = () => ({
+  components: {
+    JumpToPath: JumpFromPathToLine, // SwaggerUI component
+  },
+  statePlugins: {
+    editor: {
+      selectors: {
+        bestJumpPath,
+      },
+    },
+  },
+});
+
+export default EditorContentJumpFromPathToLinePlugin;

--- a/src/plugins/editor-content-jump-from-path-to-line/selectors.js
+++ b/src/plugins/editor-content-jump-from-path-to-line/selectors.js
@@ -1,0 +1,61 @@
+/* eslint-disable import/prefer-default-export */
+import { createSelector } from 'reselect';
+import { List } from 'immutable';
+
+const transformArrayToStringPath = (arr) => {
+  if (arr.at(0) !== '/') {
+    return `/${arr.join('')}`;
+  }
+  return arr.join('/');
+};
+
+const transformImListToStringPath = (list) => {
+  const arr = list.toJS();
+  if (arr.at(0) !== '/') {
+    return `/${arr.join('')}`;
+  }
+  return arr.join('');
+};
+
+// compared to `path`, each element inside `specPath` does not contain leading `/`
+const transformArrayToStringSpecPath = (arr) => {
+  if (arr.at(0) !== '/') {
+    return `/${arr.join('/')}`;
+  }
+  return arr.join('/');
+};
+
+// compared to `path`, each element inside `specPath` does not contain leading `/`
+const transformImListToStringSpecPath = (list) => {
+  const arr = list.toJS();
+  if (arr.at(0) !== '/') {
+    return `/${arr.join('/')}`;
+  }
+  return arr.join('/');
+};
+
+// apidom-ls expects a String as arg
+export const bestJumpPath = createSelector(
+  (state, pathObj) => pathObj, // input from arg to forward to output
+  ({ path, specPath }) => {
+    if (path && typeof path === 'string') {
+      return path;
+    }
+    if (path && Array.isArray(path) && path.length > 0) {
+      return transformArrayToStringPath(path);
+    }
+    if (path && List.isList(path) && path.size > 0) {
+      return transformImListToStringPath(path);
+    }
+    if (specPath && typeof specPath === 'string') {
+      return specPath;
+    }
+    if (specPath && Array.isArray(specPath) && specPath.length > 0) {
+      return transformArrayToStringSpecPath(specPath);
+    }
+    if (specPath && List.isList(specPath) && specPath.size > 0) {
+      return transformImListToStringSpecPath(specPath);
+    }
+    return '';
+  }
+);

--- a/src/plugins/editor-monaco/actions.js
+++ b/src/plugins/editor-monaco/actions.js
@@ -2,6 +2,9 @@ export const EDITOR_UPDATE_THEME = 'editor_update_theme';
 export const EDITOR_ERROR_MARKERS = 'editor_error_markers';
 export const EDITOR_JUMP_TO_EDITOR_MARKER = 'editor_jump_to_editor_marker';
 export const EDITOR_CLEAR_JUMP_TO_EDITOR_MARKER = 'editor_clear_jump_to_editor_marker';
+export const EDITOR_SET_REQUEST_JUMP_TO_EDITOR_MARKER = 'editor_set_request_jump_to_editor_marker';
+export const EDITOR_CLEAR_REQUEST_JUMP_TO_EDITOR_MARKER =
+  'editor_clear_request_jump_to_editor_marker';
 
 export const updateEditorTheme = (theme = 'my-vs-dark') => {
   return {
@@ -25,5 +28,17 @@ export const clearJumpToEditorMarker = () => {
   return {
     payload: {},
     type: EDITOR_CLEAR_JUMP_TO_EDITOR_MARKER,
+  };
+};
+export const setRequestJumpToEditorMarker = (marker = {}) => {
+  return {
+    payload: marker,
+    type: EDITOR_SET_REQUEST_JUMP_TO_EDITOR_MARKER,
+  };
+};
+export const clearRequestJumpToEditorMarker = () => {
+  return {
+    payload: {},
+    type: EDITOR_CLEAR_REQUEST_JUMP_TO_EDITOR_MARKER,
   };
 };

--- a/src/plugins/editor-monaco/components/MonacoEditor/MonacoEditorContainer.jsx
+++ b/src/plugins/editor-monaco/components/MonacoEditor/MonacoEditorContainer.jsx
@@ -6,6 +6,7 @@ import MonacoEditor from './MonacoEditor.jsx';
 const MonacoEditorContainer = ({ editorActions, editorSelectors, isReadOnly }) => {
   const theme = editorSelectors.selectEditorTheme();
   const jumpToMarker = editorSelectors.selectEditorJumpToMarker();
+  const requestJumpToMarker = editorSelectors.selectEditorRequestJumpToMarker();
   const value = editorSelectors.selectContent();
 
   const handleEditorDidMount = useCallback(
@@ -41,6 +42,17 @@ const MonacoEditorContainer = ({ editorActions, editorSelectors, isReadOnly }) =
     editorActions.clearJumpToEditorMarker();
   }, [editorActions]);
 
+  const handleSetJumpToEditorMarker = useCallback(
+    (marker) => {
+      editorActions.setJumpToEditorMarker(marker);
+    },
+    [editorActions]
+  );
+
+  const handleClearRequestJumpToEditorMarker = useCallback(() => {
+    editorActions.clearRequestJumpToEditorMarker();
+  }, [editorActions]);
+
   return (
     <MonacoEditor
       language="apidom"
@@ -48,11 +60,14 @@ const MonacoEditorContainer = ({ editorActions, editorSelectors, isReadOnly }) =
       value={value}
       isReadOnly={isReadOnly}
       jumpToMarker={jumpToMarker}
+      requestJumpToMarker={requestJumpToMarker}
       onChange={handleChangeEditorValue}
       onMount={handleEditorDidMount}
       onWillUnmount={handleEditorWillUnmount}
       onEditorMarkersDidChange={handleEditorMarkersDidChange}
       onClearJumpToMarker={handleClearJumpToEditorMarker}
+      onSetRequestJumpToMarker={handleSetJumpToEditorMarker}
+      onClearRequestJumpToMarker={handleClearRequestJumpToEditorMarker}
     />
   );
 };
@@ -65,11 +80,14 @@ MonacoEditorContainer.propTypes = {
     setContentDebounced: PropTypes.func.isRequired,
     updateEditorMarkers: PropTypes.func.isRequired,
     clearJumpToEditorMarker: PropTypes.func.isRequired,
+    setJumpToEditorMarker: PropTypes.func.isRequired,
+    clearRequestJumpToEditorMarker: PropTypes.func.isRequired,
   }).isRequired,
   editorSelectors: PropTypes.shape({
     selectContent: PropTypes.func.isRequired,
     selectEditorTheme: PropTypes.func.isRequired,
     selectEditorJumpToMarker: PropTypes.func.isRequired,
+    selectEditorRequestJumpToMarker: PropTypes.func.isRequired,
   }).isRequired,
 };
 

--- a/src/plugins/editor-monaco/index.js
+++ b/src/plugins/editor-monaco/index.js
@@ -10,9 +10,16 @@ import {
   updateEditorMarkers,
   setJumpToEditorMarker,
   clearJumpToEditorMarker,
+  setRequestJumpToEditorMarker,
+  clearRequestJumpToEditorMarker,
 } from './actions.js';
 import reducers from './reducers.js';
-import { selectEditorTheme, selectEditorMarkers, selectEditorJumpToMarker } from './selectors.js';
+import {
+  selectEditorTheme,
+  selectEditorMarkers,
+  selectEditorJumpToMarker,
+  selectEditorRequestJumpToMarker,
+} from './selectors.js';
 import makeAfterLoad from './after-load.js';
 
 const EditorMonacoPlugin = (opts = {}) => {
@@ -40,12 +47,15 @@ const EditorMonacoPlugin = (opts = {}) => {
           updateEditorMarkers,
           setJumpToEditorMarker,
           clearJumpToEditorMarker,
+          setRequestJumpToEditorMarker,
+          clearRequestJumpToEditorMarker,
         },
         reducers,
         selectors: {
           selectEditorTheme,
           selectEditorMarkers,
           selectEditorJumpToMarker,
+          selectEditorRequestJumpToMarker,
         },
       },
     },

--- a/src/plugins/editor-monaco/reducers.js
+++ b/src/plugins/editor-monaco/reducers.js
@@ -3,6 +3,8 @@ import {
   EDITOR_ERROR_MARKERS,
   EDITOR_JUMP_TO_EDITOR_MARKER,
   EDITOR_CLEAR_JUMP_TO_EDITOR_MARKER,
+  EDITOR_SET_REQUEST_JUMP_TO_EDITOR_MARKER,
+  EDITOR_CLEAR_REQUEST_JUMP_TO_EDITOR_MARKER,
 } from './actions.js';
 
 const reducers = {
@@ -17,6 +19,12 @@ const reducers = {
   },
   [EDITOR_CLEAR_JUMP_TO_EDITOR_MARKER]: (state, action) => {
     return state.set('editorJumpToMarker', action.payload);
+  },
+  [EDITOR_SET_REQUEST_JUMP_TO_EDITOR_MARKER]: (state, action) => {
+    return state.set('editorRequestJumpToMarker', action.payload);
+  },
+  [EDITOR_CLEAR_REQUEST_JUMP_TO_EDITOR_MARKER]: (state, action) => {
+    return state.set('editorRequestJumpToMarker', action.payload);
   },
 };
 

--- a/src/plugins/editor-monaco/selectors.js
+++ b/src/plugins/editor-monaco/selectors.js
@@ -15,3 +15,5 @@ export const selectEditorJumpToMarker = createSelector(
     return editorJumpToMarker || {};
   }
 );
+
+export const selectEditorRequestJumpToMarker = (state) => state.get('editorRequestJumpToMarker');

--- a/src/plugins/editor-monaco/utils/monaco-jump-from-path-to-line.js
+++ b/src/plugins/editor-monaco/utils/monaco-jump-from-path-to-line.js
@@ -1,0 +1,34 @@
+import { getLanguageService } from '@swagger-api/apidom-ls';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+
+export async function requestGetJsonPointerPosition(editor, jsonPointer) {
+  const apidomContext = {
+    defaultLanguageContent: {
+      namespace: 'asyncapi',
+    },
+  };
+  const languageService = getLanguageService(apidomContext);
+
+  try {
+    const textDoc = TextDocument.create(
+      editor.getModel().uri.toString(),
+      // editor.getModel().getModeId(), // undefined; so hardcoding `yaml`
+      'yaml',
+      editor.getModel().getVersionId(),
+      editor.getModel().getValue()
+    );
+    const result = await languageService.getJsonPointerPosition(textDoc, jsonPointer);
+    if (!result) {
+      return { error: 'an error has occured for: getJsonPointerPosition' };
+    }
+    const { line, character } = result;
+    // map to Monaco interface
+    const offset = 1;
+    const monacoPosition = { startLineNumber: line, startColumn: character - offset };
+    return { data: monacoPosition };
+  } catch (e) {
+    return { error: e.message };
+  }
+}
+
+export default { requestGetJsonPointerPosition };


### PR DESCRIPTION
* requires apidom-ls@0.36.0 or greater

* maps position from apidom-ls to monaco interface

* maintains legacy compatibility with `path` and `specPath` props

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Re-integrate features from PR #3244. For details, refer to #3244.

Minor difference in this version here, in assigning `selectors.bestJumpPath` to `editor` statePlugin instead of the original `spec` statePlugin. This plugin otherwise had no direct interaction with SwaggerUI `spec` state or its selectors. 

Also some minor renaming changes.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Plugin was removed during the #3241, and now is re-integrated.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
