### PR TITLE
feat: add ability to integrate preview plugins with SwaggerUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,43 @@ Sample environment variable values can be found in `.env` file. For more informa
 environment variables, please refer to [adding Custom Environment Variables](https://create-react-app.dev/docs/adding-custom-environment-variables/)
 section of Create React App documentation.
 
+### Using preview plugins in SwaggerUI
+
+SwaggerEditor comes with number of `preview` plugins that are responsible for rendering
+the definition that's being created in the editor. These plugins include:
+
+- **EditorPreviewAsyncAPIPlugin** - AsyncAPI specification rendering support
+- **EditorPreviewAPIDesignSystemsPlugin** - API Design Systems rendering support
+
+With a bit of adapting, we can use these plugins with SwaggerUI to provide ability
+to render AsyncAPI or API Design Systems definitions with SwaggerUI.
+
+```js
+import React from 'react';
+import ReactDOM from 'react-dom';
+import SwaggerUI from 'swagger-ui-react';
+import 'swagger-ui-react/swagger-ui.css';
+import SwaggerEditor from '@swagger-api/swagger-editor';
+
+const plugins = [
+  SwaggerEditor.plugins.EditorContentType,
+  SwaggerEditor.plugins.EditorPreviewAsyncAPI,
+  SwaggerEditor.plugins.EditorPreviewAPIDesignSystems,
+  SwaggerEditor.plugins.SwaggerUIAdapter,
+];
+
+ReactDOM.render(
+  <SwaggerUI
+    plugins={plugins}
+    url="https://raw.githubusercontent.com/asyncapi/spec/v2.4.0/examples/streetlights-kafka.yml"
+  />,
+  document.getElementById('swagger-ui')
+);
+```
+
+The key here is `SwaggerUIAdapter` plugin which adapts SwaggerEditor plugins to use
+directly with SwaggerUI.
+
 ## Docker
 Once we build the app, we can also build and run a Docker container.
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,6 +24,7 @@ import EditorContentTypePlugin from './plugins/editor-content-type/index.js';
 import EditorContentPersistencePlugin from './plugins/editor-content-persistence/index.js';
 import EditorContentFixturesPlugin from './plugins/editor-content-fixtures/index.js';
 import EditorContentJumpFromPathToLinePlugin from './plugins/editor-content-jump-from-path-to-line/index.js';
+import SwaggerUIAdapterPlugin from './plugins/swagger-ui-adapter/index.js';
 
 const SafeRenderPlugin = (system) =>
   SwaggerUI.plugins.SafeRender({
@@ -75,6 +76,7 @@ SwaggerEditor.plugins = {
   TopBar: TopBarPlugin,
   SplashScreenPlugin,
   Layout: LayoutPlugin,
+  SwaggerUIAdapter: SwaggerUIAdapterPlugin,
 };
 SwaggerEditor.presets = {
   textarea: () => [

--- a/src/plugins/editor-content-type/actions.js
+++ b/src/plugins/editor-content-type/actions.js
@@ -66,8 +66,7 @@ export const detectContentType = (content) => {
         const version = groups?.version_json;
         const contentType = `application/vnd.aai.asyncapi+json;version=${version}`;
 
-        editorActions.detectContentTypeSuccess({ contentType, content, requestId });
-        return;
+        return editorActions.detectContentTypeSuccess({ contentType, content, requestId });
       }
 
       const asyncApi2YAMLMatch = content.match(detectionRegExpAsyncAPIYAML2);
@@ -76,16 +75,14 @@ export const detectContentType = (content) => {
         const version = groups?.version_json || groups?.version_yaml;
         const contentType = `application/vnd.aai.asyncapi+yaml;version=${version}`;
 
-        editorActions.detectContentTypeSuccess({ contentType, content, requestId });
-        return;
+        return editorActions.detectContentTypeSuccess({ contentType, content, requestId });
       }
 
       const openApi20JSONMatch = content.match(/"swagger"\s*:\s*"(?<version_json>2\.0)"/);
       if (openApi20JSONMatch !== null && fn.isValidJSONObject(content)) {
         const contentType = 'application/vnd.oai.openapi+json;version=2.0';
 
-        editorActions.detectContentTypeSuccess({ contentType, content, requestId });
-        return;
+        return editorActions.detectContentTypeSuccess({ contentType, content, requestId });
       }
 
       const openApi2YAMLMatch = content.match(
@@ -94,8 +91,7 @@ export const detectContentType = (content) => {
       if (openApi2YAMLMatch !== null && fn.isValidYAMLObject(content)) {
         const contentType = 'application/vnd.oai.openapi+yaml;version=2.0';
 
-        editorActions.detectContentTypeSuccess({ contentType, content, requestId });
-        return;
+        return editorActions.detectContentTypeSuccess({ contentType, content, requestId });
       }
 
       const openApi30xJSONMatch = content.match(/"openapi"\s*:\s*"(?<version_json>3\.0\.\d+)"/);
@@ -104,8 +100,7 @@ export const detectContentType = (content) => {
         const version = groups?.version_json;
         const contentType = `application/vnd.oai.openapi+json;version=${version}`;
 
-        editorActions.detectContentTypeSuccess({ contentType, content, requestId });
-        return;
+        return editorActions.detectContentTypeSuccess({ contentType, content, requestId });
       }
 
       const openApi30xYAMLMatch = content.match(
@@ -116,8 +111,7 @@ export const detectContentType = (content) => {
         const version = groups?.version_json || groups?.version_yaml;
         const contentType = `application/vnd.oai.openapi+json;version=${version}`;
 
-        editorActions.detectContentTypeSuccess({ contentType, content, requestId });
-        return;
+        return editorActions.detectContentTypeSuccess({ contentType, content, requestId });
       }
 
       const openApi31xJSONMatch = content.match(detectionRegExpOpenAPIJSON31x);
@@ -126,8 +120,7 @@ export const detectContentType = (content) => {
         const version = groups?.version_json;
         const contentType = `application/vnd.oai.openapi+json;version=${version}`;
 
-        editorActions.detectContentTypeSuccess({ contentType, content, requestId });
-        return;
+        return editorActions.detectContentTypeSuccess({ contentType, content, requestId });
       }
 
       const openApi31xYAMLMatch = content.match(detectionRegExpOpenAPIYAML31x);
@@ -136,8 +129,7 @@ export const detectContentType = (content) => {
         const version = groups?.version_json || groups?.version_yaml;
         const contentType = `application/vnd.oai.openapi+json;version=${version}`;
 
-        editorActions.detectContentTypeSuccess({ contentType, content, requestId });
-        return;
+        return editorActions.detectContentTypeSuccess({ contentType, content, requestId });
       }
 
       const apiDesignSystemsJSONMatch = content.match(detectionRegExpApiDesignSystemsJSON);
@@ -146,8 +138,7 @@ export const detectContentType = (content) => {
         const version = groups?.version_json;
         const contentType = `application/vnd.aai.apidesignsystems+json;version=${version}`;
 
-        editorActions.detectContentTypeSuccess({ contentType, content, requestId });
-        return;
+        return editorActions.detectContentTypeSuccess({ contentType, content, requestId });
       }
 
       const apiDesignSystemsYAMLMatch = content.match(detectionRegExpApiDesignSystemsYAML);
@@ -156,31 +147,28 @@ export const detectContentType = (content) => {
         const version = groups?.version_json || groups?.version_yaml;
         const contentType = `application/vnd.aai.apidesignsystems+yaml;version=${version}`;
 
-        editorActions.detectContentTypeSuccess({ contentType, content, requestId });
-        return;
+        return editorActions.detectContentTypeSuccess({ contentType, content, requestId });
       }
 
       if (fn.isValidJSON(content)) {
         const contentType = 'application/json';
 
-        editorActions.detectContentTypeSuccess({ contentType, content, requestId });
-        return;
+        return editorActions.detectContentTypeSuccess({ contentType, content, requestId });
       }
 
       if (fn.isValidYAML(content)) {
         const contentType = 'text/yaml';
 
-        editorActions.detectContentTypeSuccess({ contentType, content, requestId });
-        return;
+        return editorActions.detectContentTypeSuccess({ contentType, content, requestId });
       }
 
-      editorActions.detectContentTypeFailure({
+      return editorActions.detectContentTypeFailure({
         error: new Error('No content type detected'),
         content,
         requestId,
       });
     } catch (error) {
-      editorActions.detectContentTypeFailure({ error, content, requestId });
+      return editorActions.detectContentTypeFailure({ error, content, requestId });
     }
   };
 };

--- a/src/plugins/swagger-ui-adapter/index.js
+++ b/src/plugins/swagger-ui-adapter/index.js
@@ -1,0 +1,25 @@
+import { updateSpec as updateSpecWrap } from './wrap-actions.js';
+import BaseLayoutWrapper from './wrap-components/BaseLayout.jsx';
+
+/**
+ * This plugin adapts plugins from this codebase to SwaggerUI.
+ * Using this adapter, one can use SwaggerUI to preview multiple
+ * specifications.
+ */
+
+const SwaggerUIAdapterPlugin = () => {
+  return {
+    wrapComponents: {
+      BaseLayout: BaseLayoutWrapper,
+    },
+    statePlugins: {
+      spec: {
+        wrapActions: {
+          updateSpec: updateSpecWrap,
+        },
+      },
+    },
+  };
+};
+
+export default SwaggerUIAdapterPlugin;

--- a/src/plugins/swagger-ui-adapter/wrap-actions.js
+++ b/src/plugins/swagger-ui-adapter/wrap-actions.js
@@ -1,0 +1,7 @@
+// eslint-disable-next-line import/prefer-default-export
+export const updateSpec = (oriAction, system) => (spec) => {
+  const { editorActions } = system;
+
+  oriAction(spec);
+  editorActions.detectContentType(spec, system);
+};

--- a/src/plugins/swagger-ui-adapter/wrap-components/BaseLayout.jsx
+++ b/src/plugins/swagger-ui-adapter/wrap-components/BaseLayout.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const BaseLayoutWrapper = (Original, system) => {
+  const BaseLayout = ({ getComponent, editorSelectors }) => {
+    const EditorPreviewAsyncAPI = getComponent('EditorPreviewAsyncAPI', true);
+    const EditorPreviewAPIDesignSystems = getComponent('EditorPreviewAPIDesignSystems', true);
+
+    if (editorSelectors.selectIsContentTypeAsyncAPI2()) {
+      return <EditorPreviewAsyncAPI />;
+    }
+
+    if (editorSelectors.selectIsContentTypeAPIDesignSystems()) {
+      return <EditorPreviewAPIDesignSystems />;
+    }
+
+    if (editorSelectors.selectContentType()) {
+      return <Original {...system} />; // eslint-disable-line react/jsx-props-no-spreading
+    }
+
+    return (
+      <div className="swagger-ui swagger-container">
+        <div className="swagger-ui">
+          <div className="info">
+            <div className="loading-container">
+              <div className="loading" />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  BaseLayout.propTypes = {
+    getComponent: PropTypes.func.isRequired,
+    editorSelectors: PropTypes.shape({
+      selectIsContentTypeAsyncAPI2: PropTypes.func.isRequired,
+      selectIsContentTypeAPIDesignSystems: PropTypes.func.isRequired,
+      selectIsContentTypeOpenAPI: PropTypes.func.isRequired,
+      selectContentType: PropTypes.func.isRequired,
+    }).isRequired,
+  };
+
+  return BaseLayout;
+};
+
+export default BaseLayoutWrapper;


### PR DESCRIPTION
### Using preview plugins in SwaggerUI

SwaggerEditor comes with number of `preview` plugins that are responsible for rendering
the definition that's being created in the editor. These plugins include:

- **EditorPreviewAsyncAPIPlugin** - AsyncAPI specification rendering support
- **EditorPreviewAPIDesignSystemsPlugin** - API Design Systems rendering support

With a bit of adapting, we can use these plugins with SwaggerUI to provide ability
to render AsyncAPI or API Design Systems definitions with SwaggerUI.

```js
import React from 'react';
import ReactDOM from 'react-dom';
import SwaggerUI from 'swagger-ui-react';
import 'swagger-ui-react/swagger-ui.css';
import SwaggerEditor from '@swagger-api/swagger-editor';

const plugins = [
  SwaggerEditor.plugins.EditorContentType,
  SwaggerEditor.plugins.EditorPreviewAsyncAPI,
  SwaggerEditor.plugins.EditorPreviewAPIDesignSystems,
  SwaggerEditor.plugins.SwaggerUIAdapter,
];

ReactDOM.render(
  <SwaggerUI
    plugins={plugins}
    url="https://raw.githubusercontent.com/asyncapi/spec/v2.4.0/examples/streetlights-kafka.yml"
  />,
  document.getElementById('swagger-ui')
);
```

The key here is `SwaggerUIAdapter` plugin which adapts SwaggerEditor plugins to use
directly with SwaggerUI.