### PR TITLE
feat(topbar): load some fixtures as YAML

### DIFF
--- a/src/plugins/top-bar/components/EditMenu/EditMenu.jsx
+++ b/src/plugins/top-bar/components/EditMenu/EditMenu.jsx
@@ -52,17 +52,21 @@ const EditMenu = (props) => {
   const handleConvertOpenAPI20ToOpenAPI30xClick = useCallback(async () => {
     await editMenuHandler.current.convertOpenAPI20ToOpenAPI30xClick();
   }, []);
-  const handleLoadOpenAPI20FixtureClick = useCallback(() => {
-    editMenuHandler.current.loadOpenAPI20Fixture();
+  const handleLoadOpenAPI20FixtureClick = useCallback(async () => {
+    await editMenuHandler.current.loadOpenAPI20Fixture();
+    await editMenuHandler.current.convertToYAML();
   }, []);
-  const handleLoadOpenAPI30FixtureClick = useCallback(() => {
-    editMenuHandler.current.loadOpenAPI30Fixture();
+  const handleLoadOpenAPI30FixtureClick = useCallback(async () => {
+    await editMenuHandler.current.loadOpenAPI30Fixture();
+    await editMenuHandler.current.convertToYAML();
   }, []);
-  const handleLoadOpenAPI31FixtureClick = useCallback(() => {
-    editMenuHandler.current.loadOpenAPI31Fixture();
+  const handleLoadOpenAPI31FixtureClick = useCallback(async () => {
+    await editMenuHandler.current.loadOpenAPI31Fixture();
+    await editMenuHandler.current.convertToYAML();
   }, []);
-  const handleLoadAsyncAPI24FixtureClick = useCallback(() => {
-    editMenuHandler.current.loadAsyncAPI24Fixture();
+  const handleLoadAsyncAPI24FixtureClick = useCallback(async () => {
+    await editMenuHandler.current.loadAsyncAPI24Fixture();
+    await editMenuHandler.current.convertToYAML();
   }, []);
   const handleLoadAsyncAPI24PetstoreFixtureClick = useCallback(() => {
     editMenuHandler.current.loadAsyncAPI24PetstoreFixture();

--- a/test/cypress/integration/plugin.top-bar.spec.js
+++ b/test/cypress/integration/plugin.top-bar.spec.js
@@ -29,5 +29,28 @@ describe('Topbar', () => {
       cy.contains('Clear').trigger('mousemove').click();
       cy.get('.view-lines > :nth-child(1)').should('to.have.text', '');
     });
+    it('should be able to Load a fixture as YAML', () => {
+      /**
+       * Fixtures are JSON
+       * YAML option is progammatically set per menu item
+       */
+      cy.contains('Edit').click();
+      cy.contains('Load OpenAPI 3.0 Fixture').trigger('mousemove').click();
+      cy.get('.view-lines > :nth-child(1)')
+        .should('contains.text', 'openapi')
+        .should('not.have.text', '{')
+        .should('not.have.text', '"');
+    });
+    it('should be able to Load a fixture as JSON', () => {
+      /**
+       * Final production version might not contain
+       * a fixture that we intend to load as JSON.
+       * If so, please disable this test
+       */
+      cy.contains('Edit').click();
+      cy.contains('Load AsyncAPI 2.4 Petstore Fixture').trigger('mousemove').click();
+      cy.get('.view-lines > :nth-child(1)').should('contains.text', '{');
+      cy.get('.view-lines > :nth-child(2)').should('contains.text', '"asyncapi"'); // note the double quotes
+    });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Current fixtures are in JSON format. Select menu items should load and present these fixtures as YAML.

convert to YAML:
- OAS2.0
- OAS3.0
- OAS3.1
- AsyncAPI 2.4

leave as JSON:
- AsyncAPI 2.4 Petstore
- API Design Systems

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

It's easier for users to work in YAML. Also, this matches behavior from legacy SwaggerEditor

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

new Cypress tests. One for YAML, one for JSON

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
