### PR TITLE
feat: swagger-ui fallback page for oas3.1

### DIFF
--- a/src/plugins/editor-preview-swagger-ui/components/EditorPreviewSwaggerUIFallback.jsx
+++ b/src/plugins/editor-preview-swagger-ui/components/EditorPreviewSwaggerUIFallback.jsx
@@ -1,0 +1,29 @@
+const EditorPreviewSwaggerUIFallback = () => (
+  <div className="swagger-editor__editor-preview-fallback swagger-ui">
+    <div className="version-pragma">
+      <div className="version-pragma__message">
+        <div>
+          <h3>Unable to render editor content</h3>
+          <p>
+            SwaggerUI does not currently support rendering of OpenAPI 3.1 definitions.
+            <p>
+              It is in the SwaggerUI roadmap to fully support rendering of OpenAPI 3.1 definitions.
+              For additional information, please refer to this Github{' '}
+              <a href="https://github.com/swagger-api/swagger-ui/issues/5891">issue</a>.
+            </p>
+          </p>
+          <p>
+            However, SwaggerEditor itself does support OpenAPI 3.1 within its editing experience.
+            This includes OpenAPI 3.1 validation rules and semantic highlighting.
+          </p>
+          <p>
+            Thus, you may continue to write and update your OpenAPI 3.1 definitions with confidence
+            in conformance to the OpenAPI 3.1 specification.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default EditorPreviewSwaggerUIFallback;

--- a/src/plugins/editor-preview-swagger-ui/index.js
+++ b/src/plugins/editor-preview-swagger-ui/index.js
@@ -1,4 +1,5 @@
 import EditorPreviewSwaggerUI from './components/EditorPreviewSwaggerUI.jsx';
+import EditorPreviewSwaggerUIFallback from './components/EditorPreviewSwaggerUIFallback.jsx';
 import EditorPreviewWrapper from './wrap-components/EditorPreviewWrapper.jsx';
 import { previewUnmounted } from './actions.js';
 import {
@@ -9,6 +10,7 @@ import {
 const EditorPreviewSwaggerUIPlugin = () => ({
   components: {
     EditorPreviewSwaggerUI,
+    EditorPreviewSwaggerUIFallback,
   },
   wrapComponents: {
     EditorPreview: EditorPreviewWrapper,

--- a/src/plugins/editor-preview-swagger-ui/wrap-components/EditorPreviewWrapper.jsx
+++ b/src/plugins/editor-preview-swagger-ui/wrap-components/EditorPreviewWrapper.jsx
@@ -4,10 +4,16 @@ import PropTypes from 'prop-types';
 const EditorPreviewWrapper = (Original, system) => {
   const EditorPreview = ({ getComponent, editorSelectors }) => {
     const EditorPreviewSwaggerUI = getComponent('EditorPreviewSwaggerUI', true);
-
-    return editorSelectors.selectIsContentTypeOpenAPI() ? (
-      <EditorPreviewSwaggerUI />
-    ) : (
+    const EditorPreviewSwaggerUIFallback = getComponent('EditorPreviewSwaggerUIFallback', true);
+    const isOpenAPI = editorSelectors.selectIsContentTypeOpenAPI();
+    const isOpenAPI31 = editorSelectors.selectIsContentTypeOpenAPI31x();
+    if (isOpenAPI && !isOpenAPI31) {
+      return <EditorPreviewSwaggerUI />;
+    }
+    if (isOpenAPI && isOpenAPI31) {
+      return <EditorPreviewSwaggerUIFallback />;
+    }
+    return (
       <Original {...system} /> // eslint-disable-line react/jsx-props-no-spreading
     );
   };
@@ -16,6 +22,7 @@ const EditorPreviewWrapper = (Original, system) => {
     getComponent: PropTypes.func.isRequired,
     editorSelectors: PropTypes.shape({
       selectIsContentTypeOpenAPI: PropTypes.func.isRequired,
+      selectIsContentTypeOpenAPI31x: PropTypes.func.isRequired,
     }).isRequired,
   };
 

--- a/src/plugins/layout/components/Layout/_layout.scss
+++ b/src/plugins/layout/components/Layout/_layout.scss
@@ -45,7 +45,7 @@
       .version-pragma {
         // make the version pragma message look nicer in the context
         // of the Editor
-        font-size: 1.2em;
+        font-size: 1.0em;
       }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Instead of rendering SwaggerUI's default "error" page, detect OAS3.1 and provide an internal fallback page with explanation.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Inform users that OAS3.1 rendering support with SwaggerUI is in the roadmap, but encourage editor use for OAS3.1

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

local, via Edit -> Load OpenAPI 3.1 fixture

### Screenshots (if appropriate):
![s-e-pr-3314](https://user-images.githubusercontent.com/12902658/181374669-a75df34b-dc9d-4748-a312-20af4b614341.png)



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
