### PR TITLE
fix: nested <p> in EditorPreviewSwaggerUIFallback

### DIFF
--- a/src/plugins/editor-preview-swagger-ui/components/EditorPreviewSwaggerUIFallback.jsx
+++ b/src/plugins/editor-preview-swagger-ui/components/EditorPreviewSwaggerUIFallback.jsx
@@ -4,13 +4,11 @@ const EditorPreviewSwaggerUIFallback = () => (
       <div className="version-pragma__message">
         <div>
           <h3>Unable to render editor content</h3>
+          <p>SwaggerUI does not currently support rendering of OpenAPI 3.1 definitions.</p>
           <p>
-            SwaggerUI does not currently support rendering of OpenAPI 3.1 definitions.
-            <p>
-              It is in the SwaggerUI roadmap to fully support rendering of OpenAPI 3.1 definitions.
-              For additional information, please refer to this Github{' '}
-              <a href="https://github.com/swagger-api/swagger-ui/issues/5891">issue</a>.
-            </p>
+            It is in the SwaggerUI roadmap to fully support rendering of OpenAPI 3.1 definitions.
+            For additional information, please refer to this Github{' '}
+            <a href="https://github.com/swagger-api/swagger-ui/issues/5891">issue</a>.
           </p>
           <p>
             However, SwaggerEditor itself does support OpenAPI 3.1 within its editing experience.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Fix nested <p> tag

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

console.error

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
