### PR TITLE
fix: `contentType` value returned by oas30x, oas31x YAMLMatch

### DIFF
--- a/src/plugins/editor-content-type/actions.js
+++ b/src/plugins/editor-content-type/actions.js
@@ -109,7 +109,7 @@ export const detectContentType = (content) => {
       if (openApi30xYAMLMatch !== null && fn.isValidYAMLObject(content)) {
         const { groups } = openApi30xYAMLMatch;
         const version = groups?.version_json || groups?.version_yaml;
-        const contentType = `application/vnd.oai.openapi+json;version=${version}`;
+        const contentType = `application/vnd.oai.openapi+yaml;version=${version}`;
 
         return editorActions.detectContentTypeSuccess({ contentType, content, requestId });
       }
@@ -127,7 +127,7 @@ export const detectContentType = (content) => {
       if (openApi31xYAMLMatch !== null && fn.isValidYAMLObject(content)) {
         const { groups } = openApi31xYAMLMatch;
         const version = groups?.version_json || groups?.version_yaml;
-        const contentType = `application/vnd.oai.openapi+json;version=${version}`;
+        const contentType = `application/vnd.oai.openapi+yaml;version=${version}`;
 
         return editorActions.detectContentTypeSuccess({ contentType, content, requestId });
       }

--- a/test/cypress/integration/plugin.top-bar.spec.js
+++ b/test/cypress/integration/plugin.top-bar.spec.js
@@ -29,28 +29,110 @@ describe('Topbar', () => {
       cy.contains('Clear').trigger('mousemove').click();
       cy.get('.view-lines > :nth-child(1)').should('to.have.text', '');
     });
-    it('should be able to Load a fixture as YAML', () => {
+
+    describe('should be able to Load a fixture as YAML', () => {
       /**
        * Fixtures are JSON
        * YAML option is progammatically set per menu item
        */
-      cy.contains('Edit').click();
-      cy.contains('Load OpenAPI 3.0 Fixture').trigger('mousemove').click();
-      cy.get('.view-lines > :nth-child(1)')
-        .should('contains.text', 'openapi')
-        .should('not.have.text', '{')
-        .should('not.have.text', '"');
+      it('loads OpenAPI 3.0 Fixture as YAML', () => {
+        cy.contains('Edit').click();
+        cy.contains('Load OpenAPI 3.0 Fixture').trigger('mousemove').click();
+        cy.get('.view-lines > :nth-child(1)')
+          .should('contains.text', 'openapi')
+          .should('not.have.text', '{')
+          .should('not.have.text', '"');
+      });
+      it('loads OpenAPI 3.1 Fixture as YAML', () => {
+        cy.contains('Edit').click();
+        cy.contains('Load OpenAPI 3.1 Fixture').trigger('mousemove').click();
+        cy.get('.view-lines > :nth-child(1)')
+          .should('contains.text', 'openapi')
+          .should('not.have.text', '{')
+          .should('not.have.text', '"');
+      });
+      it('loads OpenAPI 2.0 Fixture as YAML', () => {
+        cy.contains('Edit').click();
+        cy.contains('Load OpenAPI 2.0 Fixture').trigger('mousemove').click();
+        cy.get('.view-lines > :nth-child(1)')
+          .should('contains.text', 'swagger')
+          .should('not.have.text', '{')
+          .should('not.have.text', '"');
+      });
+      it('loads AsyncAPI 2.4 Fixture as YAML', () => {
+        cy.contains('Edit').click();
+        cy.contains('Load AsyncAPI 2.4 Fixture').trigger('mousemove').click();
+        cy.get('.view-lines > :nth-child(1)')
+          .should('contains.text', 'asyncapi')
+          .should('not.have.text', '{')
+          .should('not.have.text', '"');
+      });
     });
-    it('should be able to Load a fixture as JSON', () => {
+
+    describe('should be able to Load a fixture as JSON', () => {
       /**
        * Final production version might not contain
-       * a fixture that we intend to load as JSON.
-       * If so, please disable this test
+       * a fixture that we intend to load and display as JSON.
+       * If so, please disable these test(s)
        */
-      cy.contains('Edit').click();
-      cy.contains('Load AsyncAPI 2.4 Petstore Fixture').trigger('mousemove').click();
-      cy.get('.view-lines > :nth-child(1)').should('contains.text', '{');
-      cy.get('.view-lines > :nth-child(2)').should('contains.text', '"asyncapi"'); // note the double quotes
+      it('loads AsyncAPI 2.4 Petstore Fixture as JSON', () => {
+        cy.contains('Edit').click();
+        cy.contains('Load AsyncAPI 2.4 Petstore Fixture').trigger('mousemove').click();
+        cy.get('.view-lines > :nth-child(1)').should('contains.text', '{');
+        cy.get('.view-lines > :nth-child(2)').should('contains.text', '"asyncapi"'); // note the double quotes
+      });
+      it('loads API Design Systems Fixture as JSON', () => {
+        cy.contains('Edit').click();
+        cy.contains('Load API Design Systems Fixture').trigger('mousemove').click();
+        cy.get('.view-lines > :nth-child(1)').should('contains.text', '{');
+      });
+    });
+
+    describe('should display "Convert To JSON" menu item after loading fixture as YAML', () => {
+      it('displays "Convert To JSON" option for OpenAPI 3.0 Fixture', () => {
+        cy.contains('Edit').click();
+        cy.contains('Load OpenAPI 3.0 Fixture').trigger('mousemove').click();
+        cy.contains('Edit').click();
+        cy.contains('Convert to JSON').should('be.visible');
+      });
+      it('displays "Convert To JSON" option for OpenAPI 3.1 Fixture', () => {
+        cy.contains('Edit').click();
+        cy.contains('Load OpenAPI 3.1 Fixture').trigger('mousemove').click();
+        cy.contains('Edit').click();
+        cy.contains('Convert to JSON').should('be.visible');
+      });
+      it('displays "Convert To JSON" option for OpenAPI 2.0 Fixture', () => {
+        cy.contains('Edit').click();
+        cy.contains('Load OpenAPI 2.0 Fixture').trigger('mousemove').click();
+        cy.contains('Edit').click();
+        cy.contains('Convert to JSON').should('be.visible');
+      });
+      it('displays "Convert To JSON" option for AsyncAPI 2.4 Fixture', () => {
+        cy.contains('Edit').click();
+        cy.contains('Load AsyncAPI 2.4 Fixture').trigger('mousemove').click();
+        cy.contains('Edit').click();
+        cy.contains('Convert to JSON').should('be.visible');
+      });
+    });
+
+    describe('should display "Convert to YAML" menu item after loading fixture as JSON', () => {
+      /**
+       * Final production version might not contain
+       * a fixture that we intend to load and display as JSON.
+       * If so, please disable these tests
+       */
+      it('displays "Convert To YAML" option for AsyncAPI 2.4 Petstore Fixture', () => {
+        cy.contains('Edit').click();
+        cy.contains('Load AsyncAPI 2.4 Petstore Fixture').trigger('mousemove').click();
+        cy.contains('Edit').click();
+        cy.contains('Convert to YAML').should('be.visible');
+      });
+      it('displays "Convert To YAML" option for API Design Systems Fixture', () => {
+        cy.contains('Edit').click();
+        cy.contains('Load API Design Systems Fixture').trigger('mousemove').click();
+        cy.contains('Edit').click();
+        cy.contains('Convert to YAML').should('be.visible');
+      });
     });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

* Fix the return values of the OAS30x/OAS31x matchers.
* Add Cypress tests for validation `contentType` detection of YAML/JSON
* Update Cypress tests for validating YAML conversion in Editor

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

fixes #3319

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

new Cypress tests

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
