### PR TITLE
fix(top-bar): fix data handling in importUrl async thunk

### DIFF
--- a/src/plugins/top-bar/actions/import-url.js
+++ b/src/plugins/top-bar/actions/import-url.js
@@ -56,13 +56,17 @@ export const importUrl = (url) => {
   return async (system) => {
     const { editorActions } = system;
     const requestId = uid();
-
-    if (typeof url !== 'string' || url === '') {
-      return editorActions.importUrlFailure({ error: 'invalid url provided', url, requestId });
-    }
-
     const sanitizedUrl = sanitizeUrl(url);
-    editorActions.importUrlStarted({ sanitizedUrl, requestId });
+
+    editorActions.importUrlStarted({ url: sanitizedUrl, requestId });
+
+    if (sanitizedUrl === 'about:blank') {
+      return editorActions.importUrlFailure({
+        error: new Error('Invalid url provided'),
+        url: sanitizedUrl,
+        requestId,
+      });
+    }
 
     try {
       const response = await axios.get(sanitizedUrl);


### PR DESCRIPTION
Refs 8cfd2ac62af056e9a59fadc1f414a74d1dd7d56b

**Explanation**:

- sanitizer returns `about:blank` for any error so we can use that fact
- fix how data is passed to action creators
- always pass error object to error field of FSA