### PR TITLE
refactor(edit-menu): convert format using async thunk

### DIFF
--- a/src/plugins/top-bar/components/EditMenu/EditMenu.jsx
+++ b/src/plugins/top-bar/components/EditMenu/EditMenu.jsx
@@ -54,19 +54,15 @@ const EditMenu = (props) => {
   }, []);
   const handleLoadOpenAPI20FixtureClick = useCallback(async () => {
     await editMenuHandler.current.loadOpenAPI20Fixture();
-    await editMenuHandler.current.convertToYAML();
   }, []);
   const handleLoadOpenAPI30FixtureClick = useCallback(async () => {
     await editMenuHandler.current.loadOpenAPI30Fixture();
-    await editMenuHandler.current.convertToYAML();
   }, []);
   const handleLoadOpenAPI31FixtureClick = useCallback(async () => {
     await editMenuHandler.current.loadOpenAPI31Fixture();
-    await editMenuHandler.current.convertToYAML();
   }, []);
   const handleLoadAsyncAPI24FixtureClick = useCallback(async () => {
     await editMenuHandler.current.loadAsyncAPI24Fixture();
-    await editMenuHandler.current.convertToYAML();
   }, []);
   const handleLoadAsyncAPI24PetstoreFixtureClick = useCallback(() => {
     editMenuHandler.current.loadAsyncAPI24PetstoreFixture();

--- a/src/plugins/top-bar/components/EditMenu/EditMenuHandler.jsx
+++ b/src/plugins/top-bar/components/EditMenu/EditMenuHandler.jsx
@@ -26,21 +26,37 @@ const EditMenuHandler = forwardRef((props, ref) => {
     async convertOpenAPI20ToOpenAPI30xClick() {
       await convertToOpenAPI30xMenuItemHandler.current.convert();
     },
-    loadOpenAPI20Fixture() {
+    async loadOpenAPI20Fixture() {
       const content = editorContentFixturesSelectors.selectOpenAPI20JSON();
-      editorActions.setContent(content, 'fixture-load');
+      const fsa = await editorActions.convertContentToYAML(content);
+
+      if (!fsa.error) {
+        editorActions.setContent(fsa.payload, 'fixture-load');
+      }
     },
-    loadOpenAPI30Fixture() {
+    async loadOpenAPI30Fixture() {
       const content = editorContentFixturesSelectors.selectOpenAPI303JSON();
-      editorActions.setContent(content, 'fixture-load');
+      const fsa = await editorActions.convertContentToYAML(content);
+
+      if (!fsa.error) {
+        editorActions.setContent(fsa.payload, 'fixture-load');
+      }
     },
-    loadOpenAPI31Fixture() {
+    async loadOpenAPI31Fixture() {
       const content = editorContentFixturesSelectors.selectOpenAPI310JSON();
-      editorActions.setContent(content, 'fixture-load');
+      const fsa = await editorActions.convertContentToYAML(content);
+
+      if (!fsa.error) {
+        editorActions.setContent(fsa.payload, 'fixture-load');
+      }
     },
-    loadAsyncAPI24Fixture() {
+    async loadAsyncAPI24Fixture() {
       const content = editorContentFixturesSelectors.selectAsyncAPI240JSON();
-      editorActions.setContent(content, 'fixture-load');
+      const fsa = await editorActions.convertContentToYAML(content);
+
+      if (!fsa.error) {
+        editorActions.setContent(fsa.payload, 'fixture-load');
+      }
     },
     loadAsyncAPI24PetstoreFixture() {
       const content = editorContentFixturesSelectors.selectAsyncAPI240PetstoreJSON();
@@ -64,6 +80,7 @@ const EditMenuHandler = forwardRef((props, ref) => {
 EditMenuHandler.propTypes = {
   editorActions: PropTypes.shape({
     clearContent: PropTypes.func.isRequired,
+    convertContentToYAML: PropTypes.func.isRequired,
     setContent: PropTypes.func.isRequired,
   }).isRequired,
   editorContentFixturesSelectors: PropTypes.shape({


### PR DESCRIPTION
Refs ed614c521624604bcf747d146e2f9245ac42dead

Because the menu handlers were used, the effect was that editor content got dispatched twice to redux store: first time when the fixture got loaded and second time when fixture got converted and sent to editor as it's new content. 

This PR remedies the situation and uses async thunks directly in specific handlers to take care of conversion without reducing to redux store. Editor content is set only once.

Even more optimal solution exists and that is creating new selectors for YAML fixture. But IMHO this solution suffice.