### PR TITLE
refactor(test): e2e update choice of topbar fixtures

### DIFF
--- a/test/cypress/integration/plugin.top-bar.spec.js
+++ b/test/cypress/integration/plugin.top-bar.spec.js
@@ -42,7 +42,7 @@ describe('Topbar', () => {
        */
       it('should render clickable text: "Save (as JSON)', () => {
         cy.contains('Edit').click(); // Edit Menu
-        cy.contains('Load OpenAPI 3.0 Fixture').trigger('mousemove').click();
+        cy.contains('Load OpenAPI 3.0 Petstore Fixture').trigger('mousemove').click();
         cy.contains('Edit').click();
         cy.contains('Convert to JSON').trigger('mousemove').click();
         cy.contains('File').click(); // File Menu
@@ -50,7 +50,7 @@ describe('Topbar', () => {
       });
       it('should render clickable text: "Convert and Save as YAML', () => {
         cy.contains('Edit').click(); // Edit Menu
-        cy.contains('Load OpenAPI 3.0 Fixture').trigger('mousemove').click();
+        cy.contains('Load OpenAPI 3.0 Petstore Fixture').trigger('mousemove').click();
         cy.contains('Edit').click();
         cy.contains('Convert to JSON').trigger('mousemove').click();
         cy.contains('File').click(); // File Menu
@@ -67,13 +67,13 @@ describe('Topbar', () => {
        */
       it('should render clickable text: "Save (as YAML)', () => {
         cy.contains('Edit').click(); // Edit Menu
-        cy.contains('Load OpenAPI 3.0 Fixture').trigger('mousemove').click();
+        cy.contains('Load OpenAPI 3.0 Petstore Fixture').trigger('mousemove').click();
         cy.contains('File').click(); // File Menu
         cy.contains('Save (as YAML)').should('exist');
       });
       it('should render clickable text: "Convert and Save as JSON', () => {
         cy.contains('Edit').click(); // Edit Menu
-        cy.contains('Load OpenAPI 3.0 Fixture').trigger('mousemove').click();
+        cy.contains('Load OpenAPI 3.0 Petstore Fixture').trigger('mousemove').click();
         cy.contains('File').click(); // File Menu
         cy.contains('Convert and Save as JSON').should('exist');
       });
@@ -92,9 +92,9 @@ describe('Topbar', () => {
        * Fixtures are JSON
        * YAML option is progammatically set per menu item
        */
-      it('loads OpenAPI 3.0 Fixture as YAML', () => {
+      it('loads OpenAPI 3.0 Petstore Fixture as YAML', () => {
         cy.contains('Edit').click();
-        cy.contains('Load OpenAPI 3.0 Fixture').trigger('mousemove').click();
+        cy.contains('Load OpenAPI 3.0 Petstore Fixture').trigger('mousemove').click();
         cy.get('.view-lines > :nth-child(1)')
           .should('contains.text', 'openapi')
           .should('not.have.text', '{')
@@ -108,9 +108,9 @@ describe('Topbar', () => {
           .should('not.have.text', '{')
           .should('not.have.text', '"');
       });
-      it('loads OpenAPI 2.0 Fixture as YAML', () => {
+      it('loads OpenAPI 2.0 Petstore Fixture as YAML', () => {
         cy.contains('Edit').click();
-        cy.contains('Load OpenAPI 2.0 Fixture').trigger('mousemove').click();
+        cy.contains('Load OpenAPI 2.0 Petstore Fixture').trigger('mousemove').click();
         cy.get('.view-lines > :nth-child(1)')
           .should('contains.text', 'swagger')
           .should('not.have.text', '{')
@@ -146,9 +146,9 @@ describe('Topbar', () => {
     });
 
     describe('should display "Convert To JSON" menu item after loading fixture as YAML', () => {
-      it('displays "Convert To JSON" option for OpenAPI 3.0 Fixture', () => {
+      it('displays "Convert To JSON" option for OpenAPI 3.0 Petstore Fixture', () => {
         cy.contains('Edit').click();
-        cy.contains('Load OpenAPI 3.0 Fixture').trigger('mousemove').click();
+        cy.contains('Load OpenAPI 3.0 Petstore Fixture').trigger('mousemove').click();
         cy.contains('Edit').click();
         cy.contains('Convert to JSON').should('be.visible');
       });
@@ -158,9 +158,9 @@ describe('Topbar', () => {
         cy.contains('Edit').click();
         cy.contains('Convert to JSON').should('be.visible');
       });
-      it('displays "Convert To JSON" option for OpenAPI 2.0 Fixture', () => {
+      it('displays "Convert To JSON" option for OpenAPI 2.0 Petstore Fixture', () => {
         cy.contains('Edit').click();
-        cy.contains('Load OpenAPI 2.0 Fixture').trigger('mousemove').click();
+        cy.contains('Load OpenAPI 2.0 Petstore Fixture').trigger('mousemove').click();
         cy.contains('Edit').click();
         cy.contains('Convert to JSON').should('be.visible');
       });
@@ -195,13 +195,13 @@ describe('Topbar', () => {
     describe('"Convert to OpenAPI 3.0.x" menu item', () => {
       it('displays "Convert to OpenAPI 3.0.x" after loading OAS2.0 fixture', () => {
         cy.contains('Edit').click();
-        cy.contains('Load OpenAPI 2.0 Fixture').trigger('mousemove').click();
+        cy.contains('Load OpenAPI 2.0 Petstore Fixture').trigger('mousemove').click();
         cy.contains('Edit').click();
         cy.contains('Convert to OpenAPI 3.0.x').should('be.visible');
       });
       it('should not display "Convert to OpenAPI 3.0.x" after loading OAS3.x fixture', () => {
         cy.contains('Edit').click();
-        cy.contains('Load OpenAPI 3.0 Fixture').trigger('mousemove').click();
+        cy.contains('Load OpenAPI 3.0 Petstore Fixture').trigger('mousemove').click();
         cy.contains('Edit').click();
         cy.get('Convert to OpenAPI 3.0.x').should('not.exist');
       });
@@ -226,7 +226,7 @@ describe('Topbar', () => {
      */
     it('should render "Generate Server" and "Generate Client" dropdown menus when OAS2.0', () => {
       cy.contains('Edit').click();
-      cy.contains('Load OpenAPI 2.0 Fixture').trigger('mousemove').click();
+      cy.contains('Load OpenAPI 2.0 Petstore Fixture').trigger('mousemove').click();
       cy.contains('Generate Server').should('be.visible');
       cy.contains('Generate Client').should('be.visible');
       /**
@@ -241,7 +241,7 @@ describe('Topbar', () => {
     });
     it('should render "Generate Server" and "Generate Client" dropdown menus when OAS3.0.x', () => {
       cy.contains('Edit').click();
-      cy.contains('Load OpenAPI 3.0 Fixture').trigger('mousemove').click();
+      cy.contains('Load OpenAPI 3.0 Petstore Fixture').trigger('mousemove').click();
       cy.contains('Generate Server').should('be.visible');
       cy.contains('Generate Client').should('be.visible');
       /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Change `OAS2.0` and `OAS3.0` fixtures used by Cypress to use their respective Swagger Petsore version. No actual change to the fixtures themselves.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Use more long-term durable fixtures. Non Petstore fixtures are likely to be removed in the future.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

local

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
