### PR TITLE
test(e2e): preview panes from plugins

### DIFF
--- a/test/cypress/integration/plugin.editor-preview-api-design-systems.spec.js
+++ b/test/cypress/integration/plugin.editor-preview-api-design-systems.spec.js
@@ -1,0 +1,19 @@
+describe('Editor Preview Pane: AsyncAPI 2.x', () => {
+  beforeEach(() => {
+    cy.visitBlankPage();
+    cy.prepareAsyncAPI();
+    cy.waitForSplashScreen();
+  });
+  it('displays API Design Systems', () => {
+    cy.contains('Edit').click();
+    cy.contains('Load API Design Systems Fixture').trigger('mousemove').click();
+    cy.get('.title').contains('SmartBear API Guidelines').should('be.visible');
+    cy.get('.version-stamp > .version').should('be.visible').contains('ADS').should('be.visible');
+  });
+  it('hidden if not API Design Systems', () => {
+    cy.contains('Edit').click();
+    cy.contains('Load OpenAPI 3.0 Petstore Fixture').trigger('mousemove').click();
+    cy.get('.title').contains('SmartBear API Guidelines').should('not.exist');
+    cy.get('.version-stamp > .version').find('ADS').should('not.exist');
+  });
+});

--- a/test/cypress/integration/plugin.editor-preview-asyncapi.spec.js
+++ b/test/cypress/integration/plugin.editor-preview-asyncapi.spec.js
@@ -1,0 +1,19 @@
+describe('Editor Preview Pane: AsyncAPI 2.x', () => {
+  beforeEach(() => {
+    cy.visitBlankPage();
+    cy.prepareAsyncAPI();
+    cy.waitForSplashScreen();
+  });
+  it('displays AsyncAPI 2.x.x', () => {
+    cy.contains('Edit').click();
+    cy.contains('Load AsyncAPI 2.4 Streetlights Fixture').trigger('mousemove').click();
+    cy.get('#check-out-its-awesome-features').should('be.visible');
+    cy.get('#servers').should('be.visible');
+  });
+  it('hidden if not AsyncAPI 2.x.x', () => {
+    cy.contains('Edit').click();
+    cy.contains('Load OpenAPI 3.0 Petstore Fixture').trigger('mousemove').click();
+    cy.get('#check-out-its-awesome-features').should('not.exist');
+    cy.get('#servers').should('not.exist');
+  });
+});

--- a/test/cypress/integration/plugin.editor-preview-swaggerui.spec.js
+++ b/test/cypress/integration/plugin.editor-preview-swaggerui.spec.js
@@ -1,0 +1,39 @@
+describe('Editor Preview Pane: OpenAPI 2.0, 3.0.x, 3.1.x', () => {
+  beforeEach(() => {
+    cy.visitBlankPage();
+    cy.prepareAsyncAPI();
+    cy.waitForSplashScreen();
+  });
+  it('displays OAS2.0.x', () => {
+    cy.contains('Edit').click();
+    cy.contains('Load OpenAPI 2.0 Petstore Fixture').trigger('mousemove').click();
+    // `.title` and `.version-stamp` are SwaggerUI specific css classes, that should only appear in the preview pane
+    cy.get('.title').contains('Swagger Petstore 2.0').should('be.visible');
+    cy.get('.version-stamp > .version').should('not.exist');
+  });
+  it('displays OAS3.0.x', () => {
+    cy.contains('Edit').click();
+    cy.contains('Load OpenAPI 3.0 Petstore Fixture').trigger('mousemove').click();
+    // `.title` and `.version-stamp` are SwaggerUI specific css classes, that should only appear in the preview pane
+    cy.get('.title').contains('Swagger Petstore - OpenAPI 3.0').should('be.visible');
+    cy.get('.version-stamp > .version').should('be.visible').contains('OAS3').should('be.visible');
+  });
+  it('displays OAS3.1.x fallback', () => {
+    cy.contains('Edit').click();
+    cy.contains('Load OpenAPI 3.1 Fixture').trigger('mousemove').click();
+    // `.version-pragma__message` is a SwaggerEditor specific css class, that should only appear in the preview pane
+    cy.get('.version-pragma__message h3')
+      .contains('Unable to render editor content')
+      .should('be.visible');
+    cy.get('.version-pragma__message > div')
+      .contains('SwaggerUI does not currently support rendering of OpenAPI 3.1 definitions')
+      .should('be.visible');
+  });
+  it('hidden if not OAS2.0, OAS3.0.x, or OAS3.1', () => {
+    cy.contains('Edit').click();
+    cy.contains('Load AsyncAPI 2.4 Streetlights Fixture').trigger('mousemove').click();
+    // `.title` is a SwaggerUI specific css class
+    cy.get('.title').should('not.exist');
+    cy.get('Swagger Petstore').should('not.exist');
+  });
+});


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

New Cypress E2E tests that checks for expected content in the `EditorPreviewPane`.

Plugins:
* editor-preview-swagger-ui
* editor-preview-asyncapi
* editor-preview-api-design-systems

Fixtures:
* OAS2.0.x (Petstore)
* OAS3.0.x (Petstore)
* OAS3.1.x
* AsyncAPI 2.x (Streetlights)
* API Design Systems


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

BDD E2E tests for the `EditorPreviewPane`. The different plugins render different content.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

all new tests

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
