### PR TITLE
test(e2e): confirm dialog

### DIFF
--- a/test/cypress/integration/plugin.dialogs.spec.js
+++ b/test/cypress/integration/plugin.dialogs.spec.js
@@ -1,0 +1,39 @@
+describe('Dialogs: Confirm', () => {
+  /**
+   * TopBar uses the `ConfirmDialog` and `AlertDialog` components
+   * from the `Dialogs` plugin, but both are available for use by
+   * other plugins and components.
+   * The AlertDialog component is generally reserved for unxpected
+   * end user error messages, and hopefully not seen in normal use,
+   * so we do not currently test it here.
+   * */
+  beforeEach(() => {
+    cy.visitBlankPage();
+    cy.prepareAsyncAPI();
+    cy.waitForSplashScreen();
+  });
+  it('should close the Confirm Dialog via `x` button', () => {
+    cy.contains('File').click(); // File Menu
+    cy.contains('Import URL')
+      .trigger('mousemove')
+      .click()
+      .get('#input-import-url')
+      .should('be.visible')
+      .get('.close')
+      .click()
+      .get('#input-import-url')
+      .should('not.exist');
+  });
+  it('should close the Confirm Dialog via `Cancel` button', () => {
+    cy.contains('File').click(); // File Menu
+    cy.contains('Import URL')
+      .trigger('mousemove')
+      .click()
+      .get('#input-import-url')
+      .should('be.visible')
+      .get('.btn-secondary')
+      .click()
+      .get('#input-import-url')
+      .should('not.exist');
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

New Cypress E2E tests validating `cancel` operation and closing of a (confirm) dialog window. At the moment, only `TopBar` leverages the `Dialog` plugin, although future plugins and components are expected to use this plugin.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

BDD E2E test coverage for Dialog boxes.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

all new.

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
