### PR TITLE
test(e2e): cy.Commands for `prepareOasGenerator` interceptors

### DIFF
--- a/test/cypress/integration/plugin.dialogs.spec.js
+++ b/test/cypress/integration/plugin.dialogs.spec.js
@@ -10,6 +10,7 @@ describe('Dialogs: Confirm', () => {
   beforeEach(() => {
     cy.visitBlankPage();
     cy.prepareAsyncAPI();
+    cy.prepareOasGenerator();
     cy.waitForSplashScreen();
   });
   it('should close the Confirm Dialog via `x` button', () => {

--- a/test/cypress/integration/plugin.dropzone.spec.js
+++ b/test/cypress/integration/plugin.dropzone.spec.js
@@ -3,6 +3,7 @@ describe('Dropzone in Layout', () => {
     beforeEach(() => {
       cy.visitBlankPage();
       cy.prepareAsyncAPI();
+      cy.prepareOasGenerator();
       cy.waitForSplashScreen();
     });
 

--- a/test/cypress/integration/plugin.editor-monaco.spec.js
+++ b/test/cypress/integration/plugin.editor-monaco.spec.js
@@ -8,6 +8,7 @@ describe('Monaco Editor with Parser', () => {
       cy.spy(contentWindow.console, 'error').as('consoleError');
     });
     cy.prepareAsyncAPI();
+    cy.prepareOasGenerator();
     cy.waitForSplashScreen();
   });
 

--- a/test/cypress/integration/plugin.editor-persistence.spec.js
+++ b/test/cypress/integration/plugin.editor-persistence.spec.js
@@ -1,6 +1,7 @@
 describe('EditorPersistencePlugin', () => {
   beforeEach(() => {
     cy.visitBlankPage();
+    cy.prepareOasGenerator();
   });
 
   it('should load definition with provided url prop', () => {

--- a/test/cypress/integration/plugin.editor-preview-api-design-systems.spec.js
+++ b/test/cypress/integration/plugin.editor-preview-api-design-systems.spec.js
@@ -2,6 +2,7 @@ describe('Editor Preview Pane: AsyncAPI 2.x', () => {
   beforeEach(() => {
     cy.visitBlankPage();
     cy.prepareAsyncAPI();
+    cy.prepareOasGenerator();
     cy.waitForSplashScreen();
   });
   it('displays API Design Systems', () => {

--- a/test/cypress/integration/plugin.editor-preview-asyncapi.spec.js
+++ b/test/cypress/integration/plugin.editor-preview-asyncapi.spec.js
@@ -2,6 +2,7 @@ describe('Editor Preview Pane: AsyncAPI 2.x', () => {
   beforeEach(() => {
     cy.visitBlankPage();
     cy.prepareAsyncAPI();
+    cy.prepareOasGenerator();
     cy.waitForSplashScreen();
   });
   it('displays AsyncAPI 2.x.x', () => {

--- a/test/cypress/integration/plugin.editor-preview-swaggerui.spec.js
+++ b/test/cypress/integration/plugin.editor-preview-swaggerui.spec.js
@@ -2,6 +2,7 @@ describe('Editor Preview Pane: OpenAPI 2.0, 3.0.x, 3.1.x', () => {
   beforeEach(() => {
     cy.visitBlankPage();
     cy.prepareAsyncAPI();
+    cy.prepareOasGenerator();
     cy.waitForSplashScreen();
   });
   it('displays OAS2.0.x', () => {

--- a/test/cypress/integration/plugin.editor-read-only.spec.js
+++ b/test/cypress/integration/plugin.editor-read-only.spec.js
@@ -2,6 +2,7 @@ describe('read only', () => {
   beforeEach(() => {
     cy.visitBlankPage();
     cy.prepareAsyncAPI();
+    cy.prepareOasGenerator();
     cy.waitForSplashScreen();
   });
   it('should toggle between allow-write and read-only', () => {

--- a/test/cypress/integration/plugin.top-bar.spec.js
+++ b/test/cypress/integration/plugin.top-bar.spec.js
@@ -2,6 +2,7 @@ describe('Topbar', () => {
   beforeEach(() => {
     cy.visitBlankPage();
     cy.prepareAsyncAPI();
+    cy.prepareOasGenerator();
     cy.waitForSplashScreen();
   });
 

--- a/test/cypress/integration/plugin.validation-pane.spec.js
+++ b/test/cypress/integration/plugin.validation-pane.spec.js
@@ -2,6 +2,7 @@ describe('Monaco Editor with Validation Pane', () => {
   beforeEach(() => {
     cy.visitBlankPage();
     cy.prepareAsyncAPI();
+    cy.prepareOasGenerator();
     cy.waitForSplashScreen();
 
     // move down to line 2, column 3

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -65,25 +65,34 @@ Cypress.Commands.add('prepareAsyncAPI', () => {
   cy.wait('@streetlightsKafka');
 });
 
-Cypress.Commands.add('prepareOpenAPI', () => {
+Cypress.Commands.add('prepareOpenAPI30x', () => {
   cy.intercept('GET', 'https://petstore3.swagger.io/api/v3/openapi.json', {
     fixture: 'petstore-oas3.yaml',
   }).as('externalPetstore');
 
+  cy.visit('/');
+  cy.wait(['@externalPetstore']);
+});
+
+Cypress.Commands.add('prepareOasGenerator', () => {
   const staticResponse = {
     servers: ['blue', 'brown'],
     clients: ['apple', 'avocado'],
   };
 
-  cy.intercept('GET', 'https://generator3.swagger.io/api/servers', staticResponse).as(
+  cy.intercept('GET', 'https://generator3.swagger.io/api/servers', staticResponse.servers).as(
     'externalGeneratorServers'
   );
-  cy.intercept('GET', 'https://generator3.swagger.io/api/clients', staticResponse).as(
+  cy.intercept('GET', 'https://generator3.swagger.io/api/clients', staticResponse.clients).as(
     'externalGeneratorClients'
   );
 
-  cy.visit('/');
-  cy.wait(['@externalPetstore', '@externalGeneratorServers', '@externalGeneratorClients']);
+  cy.intercept('GET', 'https://generator.swagger.io/api/gen/servers', staticResponse.servers).as(
+    'externalGeneratorServersOAS2cmd'
+  );
+  cy.intercept('GET', 'https://generator.swagger.io/api/gen/clients', staticResponse.clients).as(
+    'externalGeneratorClientsOAS2cmd'
+  );
 });
 
 Cypress.Commands.add('waitForSplashScreen', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

* add Cypress command to intercept OAS2 and OAS3.0.x generator requests for list data

* Apply `cy.prepareOasGenerator()` to all Cypress tests, even if not currently actively making OAS2/OAS3 generator calls.

* Not included in this PR, intercepts to generator if user clicks on a generator menu item

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Intercept/stub original http requests to OAS2/OAS3 generator lists, to avoid needing external http during CI.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

locally, confirming external http calls for Swagger generator data is intercepted.

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
