### PR TITLE
test(e2e): oas2 and oas3 mock generator download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ yarn-error.log*
 # Cypress
 test/cypress/screenshots
 test/cypress/videos
+test/cypress/downloads
 
 # idea
 *.iml

--- a/test/cypress/integration/plugin.top-bar.spec.js
+++ b/test/cypress/integration/plugin.top-bar.spec.js
@@ -222,8 +222,6 @@ describe('Topbar', () => {
      * Clicking on a specific menu item from one of these lists
      * will auto-download a generated file via an http service
      * without further user action required
-     * We could try mocking the return request data to assert against
-     * list items, but would still need to intercept and mock download
      */
     const downloadsFolder = Cypress.config('downloadsFolder'); // use default setting
 
@@ -232,30 +230,12 @@ describe('Topbar', () => {
       cy.contains('Load OpenAPI 2.0 Petstore Fixture').trigger('mousemove').click();
       cy.contains('Generate Server').should('be.visible');
       cy.contains('Generate Client').should('be.visible');
-      /**
-       * below uses an http service, hence disabling from standard test
-       * also, we would be more interested in download action trigger
-       * rather than the specific menu item itself or its download contents
-       */
-      // cy.contains('Generate Server').click();
-      // cy.contains('ada-server').should('be.visible');
-      // cy.contains('Generate Client').click();
-      // cy.contains('ada').should('be.visible');
     });
     it('should render "Generate Server" and "Generate Client" dropdown menus when OAS3.0.x', () => {
       cy.contains('Edit').click();
       cy.contains('Load OpenAPI 3.0 Petstore Fixture').trigger('mousemove').click();
       cy.contains('Generate Server').should('be.visible');
       cy.contains('Generate Client').should('be.visible');
-      /**
-       * below uses an http service, hence disabling from standard test
-       * also, we would be more interested in download action trigger
-       * rather than the specific menu item itself or its download contents
-       */
-      // cy.contains('Generate Server').click();
-      // cy.contains('aspnetcore').should('be.visible');
-      // cy.contains('Generate Client').click();
-      // cy.contains('csharp').should('be.visible');
     });
     it('should NOT render "Generate Server" and "Generate Client" dropdown menus when OAS3.1', () => {
       cy.contains('Edit').click();

--- a/test/cypress/integration/plugin.top-bar.spec.js
+++ b/test/cypress/integration/plugin.top-bar.spec.js
@@ -293,5 +293,31 @@ describe('Topbar', () => {
         .readFile(`${downloadsFolder}/apple-client-generated.zip`)
         .should('exist');
     });
+    it('should download a generated OAS2.0 Server file', () => {
+      cy.contains('Edit').click();
+      cy.contains('Load OpenAPI 2.0 Petstore Fixture').trigger('mousemove').click();
+      cy.contains('Generate Server').should('be.visible').click();
+      cy.contains('blue') // mocked response value
+        .should('be.visible')
+        .trigger('mousemove')
+        .click()
+        .wait('@externalGeneratorServersOAS2reqDownloadUrl')
+        .wait('@externalGeneratorOas2Download')
+        .readFile(`${downloadsFolder}/blue-server-generated.zip`)
+        .should('exist');
+    });
+    it('should download a generated OAS2.0 Client file', () => {
+      cy.contains('Edit').click();
+      cy.contains('Load OpenAPI 2.0 Petstore Fixture').trigger('mousemove').click();
+      cy.contains('Generate Client').should('be.visible').click();
+      cy.contains('apple') // mocked response value
+        .should('be.visible')
+        .trigger('mousemove')
+        .click()
+        .wait('@externalGeneratorClientsOAS2reqDownloadUrl')
+        .wait('@externalGeneratorOas2Download')
+        .readFile(`${downloadsFolder}/apple-client-generated.zip`)
+        .should('exist');
+    });
   });
 });

--- a/test/cypress/integration/plugin.top-bar.spec.js
+++ b/test/cypress/integration/plugin.top-bar.spec.js
@@ -225,6 +225,8 @@ describe('Topbar', () => {
      * We could try mocking the return request data to assert against
      * list items, but would still need to intercept and mock download
      */
+    const downloadsFolder = Cypress.config('downloadsFolder'); // use default setting
+
     it('should render "Generate Server" and "Generate Client" dropdown menus when OAS2.0', () => {
       cy.contains('Edit').click();
       cy.contains('Load OpenAPI 2.0 Petstore Fixture').trigger('mousemove').click();
@@ -267,6 +269,29 @@ describe('Topbar', () => {
       cy.get('Generate Server').should('not.exist');
       cy.get('Generate Client').should('not.exist');
     });
-    it.skip('should download a generated Client file', () => {});
+    it('should download a generated OAS3.0.x Server file', () => {
+      cy.contains('Edit').click();
+      cy.contains('Load OpenAPI 3.0 Petstore Fixture').trigger('mousemove').click();
+      cy.contains('Generate Server').should('be.visible').click();
+      cy.contains('blue') // mocked response value
+        .should('be.visible')
+        .trigger('mousemove')
+        .click()
+        .wait('@externalGeneratorOas3Download')
+        .readFile(`${downloadsFolder}/blue-server-generated.zip`)
+        .should('exist');
+    });
+    it('should download a generated OAS3.0.x Client file', () => {
+      cy.contains('Edit').click();
+      cy.contains('Load OpenAPI 3.0 Petstore Fixture').trigger('mousemove').click();
+      cy.contains('Generate Client').should('be.visible').click();
+      cy.contains('apple') // mocked response value
+        .should('be.visible')
+        .trigger('mousemove')
+        .click()
+        .wait('@externalGeneratorOas3Download')
+        .readFile(`${downloadsFolder}/apple-client-generated.zip`)
+        .should('exist');
+    });
   });
 });

--- a/test/cypress/integration/plugin.top-bar.spec.js
+++ b/test/cypress/integration/plugin.top-bar.spec.js
@@ -223,6 +223,13 @@ describe('Topbar', () => {
      * will auto-download a generated file via an http service
      * without further user action required
      */
+    beforeEach(() => {
+      cy.clearDownloadsFolder();
+    });
+    after(() => {
+      cy.clearDownloadsFolder();
+    });
+
     const downloadsFolder = Cypress.config('downloadsFolder'); // use default setting
 
     it('should render "Generate Server" and "Generate Client" dropdown menus when OAS2.0', () => {

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -82,12 +82,15 @@ Cypress.Commands.add('prepareOasGenerator', () => {
   const staticFixture = {
     fixture: 'rejected.file.1', // picking a minimal file, doesn't matter what it is
   };
+  const staticOas2resDownloadUrl = {
+    link: 'https://generator.swagger.io/api/gen/download/mocked-hash',
+  };
 
   cy.intercept('GET', 'https://generator3.swagger.io/api/servers', staticResponse.servers).as(
-    'externalGeneratorServers'
+    'externalGeneratorServersOas3reqList'
   );
   cy.intercept('GET', 'https://generator3.swagger.io/api/clients', staticResponse.clients).as(
-    'externalGeneratorClients'
+    'externalGeneratorClientsOas3reqList'
   );
   // OAS3 server and client generators uses same URI
   cy.intercept('POST', 'https://generator3.swagger.io/api/generate', staticFixture).as(
@@ -95,11 +98,27 @@ Cypress.Commands.add('prepareOasGenerator', () => {
   );
 
   cy.intercept('GET', 'https://generator.swagger.io/api/gen/servers', staticResponse.servers).as(
-    'externalGeneratorServersOAS2cmd'
+    'externalGeneratorServersOAS2reqList'
   );
   cy.intercept('GET', 'https://generator.swagger.io/api/gen/clients', staticResponse.clients).as(
-    'externalGeneratorClientsOAS2cmd'
+    'externalGeneratorClientsOAS2reqList'
   );
+  cy.intercept(
+    'POST',
+    'https://generator.swagger.io/api/gen/servers/*',
+    staticOas2resDownloadUrl
+  ).as('externalGeneratorServersOAS2reqDownloadUrl');
+  cy.intercept(
+    'POST',
+    'https://generator.swagger.io/api/gen/clients/*',
+    staticOas2resDownloadUrl
+  ).as('externalGeneratorClientsOAS2reqDownloadUrl');
+  // OAS2 server and client generators uses same base URI, but all requests have an appended hash
+  cy.intercept(
+    'GET',
+    'https://generator.swagger.io/api/gen/download/mocked-hash',
+    staticFixture
+  ).as('externalGeneratorOas2Download');
 });
 
 Cypress.Commands.add('waitForSplashScreen', () => {

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -79,12 +79,19 @@ Cypress.Commands.add('prepareOasGenerator', () => {
     servers: ['blue', 'brown'],
     clients: ['apple', 'avocado'],
   };
+  const staticFixture = {
+    fixture: 'rejected.file.1', // picking a minimal file, doesn't matter what it is
+  };
 
   cy.intercept('GET', 'https://generator3.swagger.io/api/servers', staticResponse.servers).as(
     'externalGeneratorServers'
   );
   cy.intercept('GET', 'https://generator3.swagger.io/api/clients', staticResponse.clients).as(
     'externalGeneratorClients'
+  );
+  // OAS3 server and client generators uses same URI
+  cy.intercept('POST', 'https://generator3.swagger.io/api/generate', staticFixture).as(
+    'externalGeneratorOas3Download'
   );
 
   cy.intercept('GET', 'https://generator.swagger.io/api/gen/servers', staticResponse.servers).as(

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -121,6 +121,10 @@ Cypress.Commands.add('prepareOasGenerator', () => {
   ).as('externalGeneratorOas2Download');
 });
 
+Cypress.Commands.add('clearDownloadsFolder', () => {
+  cy.exec('rm cypress/downloads/*', { log: true, failOnNonZeroExit: false });
+});
+
 Cypress.Commands.add('waitForSplashScreen', () => {
   cy.get('.swagger-editor__splash-screen', { timeout: 10000 }).should('not.be.visible');
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

* oas3.0.x mocks for the generator list and the generator download
* oas2.0 mocks for the generator list and the generator download
* `clearDownloadsFolder` cypress command

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

More comprehensive E2E tests for OAS2/OAS3.0.x generator lists. Cypress assertions can now "click" on a supported generator language where `http` requests are intercepted.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

local Electron
local Chrome

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
