### PR TITLE
test(e2e): apply alertDialog assertion case in dropzone spec

### DIFF
--- a/test/cypress/integration/plugin.dialogs.spec.js
+++ b/test/cypress/integration/plugin.dialogs.spec.js
@@ -6,6 +6,7 @@ describe('Dialogs: Confirm', () => {
    * The AlertDialog component is generally reserved for unxpected
    * end user error messages, and hopefully not seen in normal use,
    * so we do not currently test it here.
+   * Ref: plugin.dropzone.spec.js contains an E2E assertion for AlertDialog
    * */
   beforeEach(() => {
     cy.visitBlankPage();

--- a/test/cypress/integration/plugin.dropzone.spec.js
+++ b/test/cypress/integration/plugin.dropzone.spec.js
@@ -15,7 +15,12 @@ describe('Dropzone in Layout', () => {
             cy.get('.modal-title')
               .should('contains.text', 'Uh oh, an error has occurred')
               .get('.modal-body > div')
-              .should('contains.text', 'Sorry, there was an error processing your file');
+              .should('contains.text', 'Sorry, there was an error processing your file')
+              // assert on AlertDialog interaction via `x` button'
+              .get('.close')
+              .click()
+              .get('.modal-title')
+              .should('not.exist');
           });
       });
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Add an assertion to close the `AlertDialog` component within the `Dropzone` E2E test. `AlertDialog` does not normally appear in "successful" workflows.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Indirect E2E test for plugin containing the `AlertDialog` component (close) interaction

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

local Electron

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
