### PR TITLE
test(e2e): add assertion for Import File

### DIFF
--- a/test/cypress/integration/plugin.top-bar.spec.js
+++ b/test/cypress/integration/plugin.top-bar.spec.js
@@ -26,9 +26,22 @@ describe('Topbar', () => {
       cy.contains('File').click(); // File Menu
       cy.contains('Import File').should('exist');
     });
-    it.skip('should be able to click on Import file', () => {
-      // Cypress does not handle native events like opening a File Dialog
-      // Jest: previously existing test only asserted that method to open file dialog box was called
+    it('should be able to "Import File" and display rendered changes', () => {
+      /**
+       * Cypress does not handle native events like opening a File Dialog.
+       * The goal of this test is to see when the file is uploaded that the
+       * editor content and rendered UI changes.
+       * In this test, it is not required for Cypress to "interact" with the
+       * "File" Menu or the "Import File" menu item. If "interact" occurs
+       * with "Import File", test runner will output console warning:
+       * "File chooser dialog can only be shown with a user activation."
+       */
+      cy.get('input[type=file]').attachFile('petstore-oas3.yaml', {
+        subjectType: 'input',
+      });
+      cy.wait(['@externalGeneratorServersOas3reqList', '@externalGeneratorClientsOas3reqList']);
+      // This assertion assumes change from non-OAS3 to OAS3, where a "badge" will exist for OAS3
+      cy.get('.version-stamp > .version').should('have.text', 'OAS3');
     });
     describe('when content is JSON', () => {
       /**
@@ -38,8 +51,8 @@ describe('Topbar', () => {
        * So here we assume that we can load a fixture as YAML,
        * then convert to JSON.
        * Then assert expected File Menu item is displayed,
-       * However, no additional assertion for click event
-       * or download event because the converter is an http service
+       * However, no additional assertion for click event or download event
+       * unless we want to check for file existence and/or file contents
        */
       it('should render clickable text: "Save (as JSON)', () => {
         cy.contains('Edit').click(); // Edit Menu
@@ -63,8 +76,8 @@ describe('Topbar', () => {
        * vs. Edit Menu, operation also will initiate a file download without additional user input
        * Here we assume that we can load a fixture as YAML.
        * Then assert expected File Menu item is displayed,
-       * However, no additional assertion for click event
-       * or download event because the converter is an http service
+       * However, no additional assertion for click event or download event
+       * unless we want to check for file existence and/or file contents
        */
       it('should render clickable text: "Save (as YAML)', () => {
         cy.contains('Edit').click(); // Edit Menu
@@ -195,6 +208,10 @@ describe('Topbar', () => {
 
     describe('"Convert to OpenAPI 3.0.x" menu item', () => {
       it('displays "Convert to OpenAPI 3.0.x" after loading OAS2.0 fixture', () => {
+        /**
+         * We don't currently assert for click event due to the converter
+         * existing as an external http service
+         */
         cy.contains('Edit').click();
         cy.contains('Load OpenAPI 2.0 Petstore Fixture').trigger('mousemove').click();
         cy.contains('Edit').click();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Import File and assert that content has changed.

Also update/correct several dev comments for other `Topbar` tests


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

BDD E2E test for Topbar -> File Menu -> Import File

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

local Electron

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
