### PR TITLE
test(e2e): mock converter to oas3

### DIFF
--- a/test/cypress/integration/plugin.top-bar.spec.js
+++ b/test/cypress/integration/plugin.top-bar.spec.js
@@ -208,14 +208,16 @@ describe('Topbar', () => {
 
     describe('"Convert to OpenAPI 3.0.x" menu item', () => {
       it('displays "Convert to OpenAPI 3.0.x" after loading OAS2.0 fixture', () => {
-        /**
-         * We don't currently assert for click event due to the converter
-         * existing as an external http service
-         */
         cy.contains('Edit').click();
         cy.contains('Load OpenAPI 2.0 Petstore Fixture').trigger('mousemove').click();
         cy.contains('Edit').click();
-        cy.contains('Convert to OpenAPI 3.0.x').should('be.visible');
+        cy.contains('Convert to OpenAPI 3.0.x')
+          .should('be.visible')
+          .trigger('mousemove')
+          .click()
+          .wait('@externalConverterToOas3');
+        // This assertion assumes change from non-OAS3 to OAS3, where a "badge" will exist for OAS3
+        cy.get('.version-stamp > .version').should('have.text', 'OAS3');
       });
       it('should not display "Convert to OpenAPI 3.0.x" after loading OAS3.x fixture', () => {
         cy.contains('Edit').click();

--- a/test/cypress/integration/plugin.top-bar.spec.js
+++ b/test/cypress/integration/plugin.top-bar.spec.js
@@ -211,13 +211,7 @@ describe('Topbar', () => {
         cy.contains('Edit').click();
         cy.contains('Load OpenAPI 2.0 Petstore Fixture').trigger('mousemove').click();
         cy.contains('Edit').click();
-        cy.contains('Convert to OpenAPI 3.0.x')
-          .should('be.visible')
-          .trigger('mousemove')
-          .click()
-          .wait('@externalConverterToOas3');
-        // This assertion assumes change from non-OAS3 to OAS3, where a "badge" will exist for OAS3
-        cy.get('.version-stamp > .version').should('have.text', 'OAS3');
+        cy.contains('Convert to OpenAPI 3.0.x').should('be.visible');
       });
       it('should not display "Convert to OpenAPI 3.0.x" after loading OAS3.x fixture', () => {
         cy.contains('Edit').click();
@@ -230,6 +224,18 @@ describe('Topbar', () => {
         cy.contains('Load AsyncAPI 2.4 Petstore Fixture').trigger('mousemove').click();
         cy.contains('Edit').click();
         cy.get('Convert to OpenAPI 3.0.x').should('not.exist');
+      });
+      it('will call external http service to "Convert to OpenAPI 3.0.x" after loading OAS2.0 fixture', () => {
+        cy.contains('Edit').click();
+        cy.contains('Load OpenAPI 2.0 Petstore Fixture').trigger('mousemove').click();
+        cy.contains('Edit').click();
+        cy.contains('Convert to OpenAPI 3.0.x')
+          .should('be.visible')
+          .trigger('mousemove')
+          .click()
+          .wait('@externalConverterToOas3');
+        // This assertion assumes change from non-OAS3 to OAS3, where a "badge" will exist for OAS3
+        cy.get('.version-stamp > .version').should('have.text', 'OAS3');
       });
     });
   });

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -119,6 +119,11 @@ Cypress.Commands.add('prepareOasGenerator', () => {
     'https://generator.swagger.io/api/gen/download/mocked-hash',
     staticFixture
   ).as('externalGeneratorOas2Download');
+
+  // always return same OAS3 fixture. not testing the actual http service to convert
+  cy.intercept('POST', 'https://converter.swagger.io/api/convert', {
+    fixture: 'petstore-oas3.yaml',
+  }).as('externalConverterToOas3');
 });
 
 Cypress.Commands.add('clearDownloadsFolder', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Add stub for external converter http service. enables onClick of menu item

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

BDD E2E test for Topbar -> Edit Menu

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

local Electron


### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
