### PR TITLE
test(e2e): workaround for flaky persistence spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "cy:dev:open": "CYPRESS_BASE_URL=http://localhost:3003 cypress open --e2e",
     "cy:dev:server": "cross-env PORT=3003 BROWSER=none ENABLE_PROGRESS_PLUGIN=false react-scripts start",
     "cy:ci": "start-server-and-test build:app:serve http://localhost:3050 cy:run:chrome",
-    "cy:run:chrome": "cypress run --browser chrome",
+    "cy:run:chrome": "cypress run --browser electron --spec 'test/cypress/integration/plugin.editor-persistence.spec.js'",
     "cy:run:firefox": "cypress run --browser firefox",
     "lint": "eslint . --ext .jsx,.js",
     "lint:fix": "eslint . --ext .jsx,.js --fix",

--- a/test/cypress/integration/plugin.editor-persistence.spec.js
+++ b/test/cypress/integration/plugin.editor-persistence.spec.js
@@ -8,24 +8,24 @@ describe('EditorPersistencePlugin', () => {
     cy.prepareAsyncAPI();
     cy.waitForSplashScreen();
 
-    cy.get('.monaco-editor .view-lines')
+    cy.get('.monaco-editor .view-lines > :nth-child(1)')
       .should('contains.text', 'asyncapi')
       .should('contains.text', '2.4.0');
   });
 
-  it.skip('should reload while keeping text change from 2.4.0 to 2.3.0', () => {
+  it('should reload while keeping text change from 2.4.0 to 2.3.0', () => {
     cy.prepareAsyncAPI();
     cy.waitForSplashScreen();
 
     const moveToPosition = `{rightArrow}{rightArrow}{rightArrow}{rightArrow}{rightArrow}{rightArrow}{rightArrow}{rightArrow}{rightArrow}{rightArrow}{rightArrow}{rightArrow}{rightArrow}`;
 
-    cy.get('.monaco-editor textarea:first', { timeout: 10000 })
+    cy.get('.monaco-editor textarea:first')
       .should('be.visible')
       .click({ force: true })
       .focused()
       .type(`${moveToPosition}{shift+rightArrow}3`);
 
-    cy.get('.monaco-editor .view-lines')
+    cy.get('.monaco-editor .view-lines > :nth-child(1)')
       .should('contains.text', '2.3.0')
       .should('not.contains.text', '2.4.0');
 
@@ -33,7 +33,7 @@ describe('EditorPersistencePlugin', () => {
     cy.reload();
 
     cy.waitForSplashScreen();
-    cy.get('.monaco-editor .view-lines')
+    cy.get('.monaco-editor .view-lines > :nth-child(1)')
       .should('contains.text', '2.3.0')
       .should('not.contains.text', '2.4.0');
   });

--- a/test/cypress/integration/plugin.editor-persistence.spec.js
+++ b/test/cypress/integration/plugin.editor-persistence.spec.js
@@ -17,9 +17,9 @@ describe('EditorPersistencePlugin', () => {
     cy.prepareAsyncAPI();
     cy.waitForSplashScreen();
 
-    const moveToPosition = `{rightArrow}{rightArrow}{rightArrow}{rightArrow}{rightArrow}{rightArrow}{rightArrow}{rightArrow}{rightArrow}{rightArrow}{rightArrow}{rightArrow}{rightArrow}`;
+    const moveToPosition = `{rightArrow}{rightArrow}{rightArrow}{rightArrow}{rightArrow}{rightArrow}{rightArrow}{rightArrow}{rightArrow}{rightArrow}{rightArrow}{rightArrow}`;
 
-    cy.get('.monaco-editor textarea:first')
+    cy.get('.monaco-editor textarea:first', { timeout: 10000 })
       .should('be.visible')
       .click({ force: true })
       .focused()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

* set Electron as the CI browser target
* update spec to match recent change to fixture
* TEMPORARY set single file for CI test. Please update before merging.

This is a WIP PR, or can be used as a workaround. Using Chrome as the current CI browser target still fails.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

ref: #3298, which has more troubleshooting details.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

local. reminder to `npm run build:app` before running `npm run cy:ci`

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
