### PR TITLE
chore(deps): extract stylesheet from deprecated react-dd-menu

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,7 @@
 swagger-editor
 Copyright 2020-2021 SmartBear Software Inc.
+
+react-dd-menu
+Copyright (c) 2015 Mikkel Laursen
+Specific Sass Cascading Style Sheet in `_dropdown-menu.less` (the file) were originally created under MIT license in https://github.com/mlaursen/react-dd-menu repository.
+Specific Sass Cascading Style Sheet have been copied into this project and modified. All modifications are licensed under Apache 2.0 License.

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "react": "=17.0.2",
         "react-ace": "^4.1.6",
         "react-addons-css-transition-group": "^15.4.2",
-        "react-dd-menu": "^2.0.0",
         "react-dom": "=17.0.2",
         "react-dropzone": "^12.0.4",
         "react-immutable-proptypes": "^2.1.0",
@@ -26026,21 +26025,6 @@
         "react": "^15.3.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/react-dd-menu": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/react-dd-menu/-/react-dd-menu-2.0.2.tgz",
-      "integrity": "sha1-o/YZWX3EVMDJPniOUkmvZkCvbMY=",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dependencies": {
-        "classnames": "^2.1.3",
-        "prop-types": "^15.5.10",
-        "react-transition-group": "^1.1.3"
-      },
-      "peerDependencies": {
-        "react": ">= 15.3.0",
-        "react-dom": ">= 15.3.0"
-      }
-    },
     "node_modules/react-debounce-input": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/react-debounce-input/-/react-debounce-input-3.3.0.tgz",
@@ -50750,16 +50734,6 @@
       "requires": {
         "copy-to-clipboard": "^3",
         "prop-types": "^15.5.8"
-      }
-    },
-    "react-dd-menu": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/react-dd-menu/-/react-dd-menu-2.0.2.tgz",
-      "integrity": "sha1-o/YZWX3EVMDJPniOUkmvZkCvbMY=",
-      "requires": {
-        "classnames": "^2.1.3",
-        "prop-types": "^15.5.10",
-        "react-transition-group": "^1.1.3"
       }
     },
     "react-debounce-input": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "react": "=17.0.2",
     "react-ace": "^4.1.6",
     "react-addons-css-transition-group": "^15.4.2",
-    "react-dd-menu": "^2.0.0",
     "react-dom": "=17.0.2",
     "react-dropzone": "^12.0.4",
     "react-immutable-proptypes": "^2.1.0",

--- a/src/styles/_dropdown-menu.less
+++ b/src/styles/_dropdown-menu.less
@@ -1,0 +1,475 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2015 Mikkel Laursen
+ * SPDX-License-Identifier: MIT
+ */
+
+/* Not really sure why, but the inverse version has a bigger gap */
+/* line 42, ../src/scss/_mixins.scss */
+.grow-from-left-enter {
+  -webkit-transform: scale(0);
+  transform: scale(0);
+  -webkit-transform-origin: 0 0;
+  transform-origin: 0 0;
+  transition: -webkit-transform 0.15s cubic-bezier(0.5, 1.8, 0.9, 0.8);
+  transition: transform 0.15s cubic-bezier(0.5, 1.8, 0.9, 0.8);
+  transition: transform 0.15s cubic-bezier(0.5, 1.8, 0.9, 0.8), -webkit-transform 0.15s cubic-bezier(0.5, 1.8, 0.9, 0.8);
+}
+
+/* line 47, ../src/scss/_mixins.scss */
+.grow-from-left-enter.grow-from-left-enter-active {
+  -webkit-transform: scale(1);
+  transform: scale(1);
+}
+
+/* line 52, ../src/scss/_mixins.scss */
+.grow-from-left-leave {
+  -webkit-transform: scale(1);
+  transform: scale(1);
+  -webkit-transform-origin: 0 0;
+  transform-origin: 0 0;
+  transition: -webkit-transform 0.15s ease-out;
+  transition: transform 0.15s ease-out;
+  transition: transform 0.15s ease-out, -webkit-transform 0.15s ease-out;
+}
+
+/* line 57, ../src/scss/_mixins.scss */
+.grow-from-left-leave.grow-from-left-leave-active {
+  -webkit-transform: scale(0);
+  transform: scale(0);
+}
+
+/* line 42, ../src/scss/_mixins.scss */
+.grow-from-right-enter {
+  -webkit-transform: scale(0);
+  transform: scale(0);
+  -webkit-transform-origin: 100% 0;
+  transform-origin: 100% 0;
+  transition: -webkit-transform 0.15s cubic-bezier(0.5, 1.8, 0.9, 0.8);
+  transition: transform 0.15s cubic-bezier(0.5, 1.8, 0.9, 0.8);
+  transition: transform 0.15s cubic-bezier(0.5, 1.8, 0.9, 0.8), -webkit-transform 0.15s cubic-bezier(0.5, 1.8, 0.9, 0.8);
+}
+
+/* line 47, ../src/scss/_mixins.scss */
+.grow-from-right-enter.grow-from-right-enter-active {
+  -webkit-transform: scale(1);
+  transform: scale(1);
+}
+
+/* line 52, ../src/scss/_mixins.scss */
+.grow-from-right-leave {
+  -webkit-transform: scale(1);
+  transform: scale(1);
+  -webkit-transform-origin: 100% 0;
+  transform-origin: 100% 0;
+  transition: -webkit-transform 0.15s ease-out;
+  transition: transform 0.15s ease-out;
+  transition: transform 0.15s ease-out, -webkit-transform 0.15s ease-out;
+}
+
+/* line 57, ../src/scss/_mixins.scss */
+.grow-from-right-leave.grow-from-right-leave-active {
+  -webkit-transform: scale(0);
+  transform: scale(0);
+}
+
+/* line 42, ../src/scss/_mixins.scss */
+.grow-from-center-enter {
+  -webkit-transform: scale(0);
+  transform: scale(0);
+  -webkit-transform-origin: 50% 0;
+  transform-origin: 50% 0;
+  transition: -webkit-transform 0.15s cubic-bezier(0.5, 1.8, 0.9, 0.8);
+  transition: transform 0.15s cubic-bezier(0.5, 1.8, 0.9, 0.8);
+  transition: transform 0.15s cubic-bezier(0.5, 1.8, 0.9, 0.8), -webkit-transform 0.15s cubic-bezier(0.5, 1.8, 0.9, 0.8);
+}
+
+/* line 47, ../src/scss/_mixins.scss */
+.grow-from-center-enter.grow-from-center-enter-active {
+  -webkit-transform: scale(1);
+  transform: scale(1);
+}
+
+/* line 52, ../src/scss/_mixins.scss */
+.grow-from-center-leave {
+  -webkit-transform: scale(1);
+  transform: scale(1);
+  -webkit-transform-origin: 50% 0;
+  transform-origin: 50% 0;
+  transition: -webkit-transform 0.15s ease-out;
+  transition: transform 0.15s ease-out;
+  transition: transform 0.15s ease-out, -webkit-transform 0.15s ease-out;
+}
+
+/* line 57, ../src/scss/_mixins.scss */
+.grow-from-center-leave.grow-from-center-leave-active {
+  -webkit-transform: scale(0);
+  transform: scale(0);
+}
+
+/* line 42, ../src/scss/_mixins.scss */
+.grow-from-up-left-enter {
+  -webkit-transform: scale(0);
+  transform: scale(0);
+  -webkit-transform-origin: 0 100%;
+  transform-origin: 0 100%;
+  transition: -webkit-transform 0.15s cubic-bezier(0.5, 1.8, 0.9, 0.8);
+  transition: transform 0.15s cubic-bezier(0.5, 1.8, 0.9, 0.8);
+  transition: transform 0.15s cubic-bezier(0.5, 1.8, 0.9, 0.8), -webkit-transform 0.15s cubic-bezier(0.5, 1.8, 0.9, 0.8);
+}
+
+/* line 47, ../src/scss/_mixins.scss */
+.grow-from-up-left-enter.grow-from-up-left-enter-active {
+  -webkit-transform: scale(1);
+  transform: scale(1);
+}
+
+/* line 52, ../src/scss/_mixins.scss */
+.grow-from-up-left-leave {
+  -webkit-transform: scale(1);
+  transform: scale(1);
+  -webkit-transform-origin: 0 100%;
+  transform-origin: 0 100%;
+  transition: -webkit-transform 0.15s ease-out;
+  transition: transform 0.15s ease-out;
+  transition: transform 0.15s ease-out, -webkit-transform 0.15s ease-out;
+}
+
+/* line 57, ../src/scss/_mixins.scss */
+.grow-from-up-left-leave.grow-from-up-left-leave-active {
+  -webkit-transform: scale(0);
+  transform: scale(0);
+}
+
+/* line 42, ../src/scss/_mixins.scss */
+.grow-from-up-center-enter {
+  -webkit-transform: scale(0);
+  transform: scale(0);
+  -webkit-transform-origin: 50% 100%;
+  transform-origin: 50% 100%;
+  transition: -webkit-transform 0.15s cubic-bezier(0.5, 1.8, 0.9, 0.8);
+  transition: transform 0.15s cubic-bezier(0.5, 1.8, 0.9, 0.8);
+  transition: transform 0.15s cubic-bezier(0.5, 1.8, 0.9, 0.8), -webkit-transform 0.15s cubic-bezier(0.5, 1.8, 0.9, 0.8);
+}
+
+/* line 47, ../src/scss/_mixins.scss */
+.grow-from-up-center-enter.grow-from-up-center-enter-active {
+  -webkit-transform: scale(1);
+  transform: scale(1);
+}
+
+/* line 52, ../src/scss/_mixins.scss */
+.grow-from-up-center-leave {
+  -webkit-transform: scale(1);
+  transform: scale(1);
+  -webkit-transform-origin: 50% 100%;
+  transform-origin: 50% 100%;
+  transition: -webkit-transform 0.15s ease-out;
+  transition: transform 0.15s ease-out;
+  transition: transform 0.15s ease-out, -webkit-transform 0.15s ease-out;
+}
+
+/* line 57, ../src/scss/_mixins.scss */
+.grow-from-up-center-leave.grow-from-up-center-leave-active {
+  -webkit-transform: scale(0);
+  transform: scale(0);
+}
+
+/* line 42, ../src/scss/_mixins.scss */
+.grow-from-up-right-enter {
+  -webkit-transform: scale(0);
+  transform: scale(0);
+  -webkit-transform-origin: 100% 100%;
+  transform-origin: 100% 100%;
+  transition: -webkit-transform 0.15s cubic-bezier(0.5, 1.8, 0.9, 0.8);
+  transition: transform 0.15s cubic-bezier(0.5, 1.8, 0.9, 0.8);
+  transition: transform 0.15s cubic-bezier(0.5, 1.8, 0.9, 0.8), -webkit-transform 0.15s cubic-bezier(0.5, 1.8, 0.9, 0.8);
+}
+
+/* line 47, ../src/scss/_mixins.scss */
+.grow-from-up-right-enter.grow-from-up-right-enter-active {
+  -webkit-transform: scale(1);
+  transform: scale(1);
+}
+
+/* line 52, ../src/scss/_mixins.scss */
+.grow-from-up-right-leave {
+  -webkit-transform: scale(1);
+  transform: scale(1);
+  -webkit-transform-origin: 100% 100%;
+  transform-origin: 100% 100%;
+  transition: -webkit-transform 0.15s ease-out;
+  transition: transform 0.15s ease-out;
+  transition: transform 0.15s ease-out, -webkit-transform 0.15s ease-out;
+}
+
+/* line 57, ../src/scss/_mixins.scss */
+.grow-from-up-right-leave.grow-from-up-right-leave-active {
+  -webkit-transform: scale(0);
+  transform: scale(0);
+}
+
+/* line 2, ../src/scss/_dd-menu.scss */
+.dd-menu {
+  display: inline-block;
+  position: relative;
+}
+
+/* line 6, ../src/scss/_dd-menu.scss */
+.dd-menu.dd-menu-center .dd-menu-items {
+  left: 50%;
+  -webkit-transform: translateX(-50%);
+  transform: translateX(-50%);
+}
+
+/* line 18, ../src/scss/_mixins.scss */
+.dd-menu.dd-menu-left .dd-menu-items {
+  left: 0;
+}
+
+/* line 5, ../src/scss/_mixins.scss */
+.dd-menu.dd-menu-left .dd-menu-items [class^='nested-']:not(.nested-reverse)>span {
+  right: 100%;
+  padding-right: 0.5em;
+}
+
+/* line 10, ../src/scss/_mixins.scss */
+.dd-menu.dd-menu-left .dd-menu-items .nested-reverse>span {
+  left: 100%;
+  padding-left: 0.5em;
+}
+
+/* line 5, ../src/scss/_mixins.scss */
+.dd-menu.dd-menu-left.dd-menu-inverse .dd-menu-items [class^='nested-']:not(.nested-reverse)>span {
+  right: 100%;
+  padding-right: 0.3em;
+}
+
+/* line 10, ../src/scss/_mixins.scss */
+.dd-menu.dd-menu-left.dd-menu-inverse .dd-menu-items .nested-reverse>span {
+  left: 100%;
+  padding-left: 0.3em;
+}
+
+/* line 18, ../src/scss/_mixins.scss */
+.dd-menu.dd-menu-right .dd-menu-items {
+  right: 0;
+}
+
+/* line 5, ../src/scss/_mixins.scss */
+.dd-menu.dd-menu-right .dd-menu-items [class^='nested-']:not(.nested-reverse)>span {
+  left: 100%;
+  padding-left: 0.5em;
+}
+
+/* line 10, ../src/scss/_mixins.scss */
+.dd-menu.dd-menu-right .dd-menu-items .nested-reverse>span {
+  right: 100%;
+  padding-right: 0.5em;
+}
+
+/* line 5, ../src/scss/_mixins.scss */
+.dd-menu.dd-menu-right.dd-menu-inverse .dd-menu-items [class^='nested-']:not(.nested-reverse)>span {
+  left: 100%;
+  padding-left: 0.3em;
+}
+
+/* line 10, ../src/scss/_mixins.scss */
+.dd-menu.dd-menu-right.dd-menu-inverse .dd-menu-items .nested-reverse>span {
+  right: 100%;
+  padding-right: 0.3em;
+}
+
+/* line 30, ../src/scss/_mixins.scss */
+.dd-menu.dd-menu-sm .dd-menu-items {
+  width: 150px;
+}
+
+/* line 30, ../src/scss/_mixins.scss */
+.dd-menu.dd-menu-md .dd-menu-items {
+  width: 300px;
+}
+
+/* line 30, ../src/scss/_mixins.scss */
+.dd-menu.dd-menu-lg .dd-menu-items {
+  width: 450px;
+}
+
+/* line 30, ../src/scss/_mixins.scss */
+.dd-menu.dd-menu-xl .dd-menu-items {
+  width: 600px;
+}
+
+/* line 15, ../src/scss/_dd-menu.scss */
+.dd-menu .dd-menu-items {
+  position: absolute;
+  z-index: 12;
+  margin: 0.5em 0 0 0;
+}
+
+/* line 20, ../src/scss/_dd-menu.scss */
+.dd-menu .dd-menu-items.dd-items-upwards {
+  bottom: 100%;
+  margin: 0 0 0.5em;
+}
+
+/* line 25, ../src/scss/_dd-menu.scss */
+.dd-menu .dd-menu-items ul,
+.dd-menu .dd-menu-items ol {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  color: #000;
+  background-color: #fefefe;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.15), 0 2px 4px rgba(0, 0, 0, 0.29);
+}
+
+/* line 34, ../src/scss/_dd-menu.scss */
+.dd-menu .dd-menu-items ul.dd-items-right li>*,
+.dd-menu .dd-menu-items ol.dd-items-right li>* {
+  text-align: right;
+}
+
+/* line 38, ../src/scss/_dd-menu.scss */
+.dd-menu .dd-menu-items ul.dd-items-left li>*,
+.dd-menu .dd-menu-items ol.dd-items-left li>* {
+  text-align: left;
+}
+
+/* line 42, ../src/scss/_dd-menu.scss */
+.dd-menu .dd-menu-items ul.dd-items-center li>*,
+.dd-menu .dd-menu-items ol.dd-items-center li>* {
+  text-align: center;
+}
+
+/* line 48, ../src/scss/_dd-menu.scss */
+.dd-menu .dd-menu-items ul li:hover:not([role="separator"]):not(.separator),
+.dd-menu .dd-menu-items ul li>*:focus,
+.dd-menu .dd-menu-items ol li:hover:not([role="separator"]):not(.separator),
+.dd-menu .dd-menu-items ol li>*:focus {
+  color: #000;
+  background-color: #bdc3c7;
+  outline: none;
+}
+
+/* line 55, ../src/scss/_dd-menu.scss */
+.dd-menu .dd-menu-items ul li>*:not(.dd-item-ignore),
+.dd-menu .dd-menu-items ol li>*:not(.dd-item-ignore) {
+  display: block;
+  width: auto;
+  min-width: 100%;
+  padding: 1em 1.5em;
+  font-family: Roboto, sans-serif;
+  white-space: pre;
+  color: inherit;
+  text-decoration: none;
+  font-size: inherit;
+}
+
+/* line 68, ../src/scss/_dd-menu.scss */
+.dd-menu .dd-menu-items ul li>button,
+.dd-menu .dd-menu-items ol li>button {
+  border: none;
+  background: transparent;
+}
+
+/* line 78, ../src/scss/_dd-menu.scss */
+.dd-menu.dd-menu-inverse .dd-menu-items ul,
+.dd-menu.dd-menu-inverse .dd-menu-items ol {
+  color: #fff;
+  background-color: #2c3e50;
+}
+
+/* line 84, ../src/scss/_dd-menu.scss */
+.dd-menu.dd-menu-inverse .dd-menu-items ul li:hover:not([role="separator"]):not(.separator),
+.dd-menu.dd-menu-inverse .dd-menu-items ul li>*:focus,
+.dd-menu.dd-menu-inverse .dd-menu-items ol li:hover:not([role="separator"]):not(.separator),
+.dd-menu.dd-menu-inverse .dd-menu-items ol li>*:focus {
+  color: #fff;
+  background-color: #34495e;
+}
+
+/* line 93, ../src/scss/_dd-menu.scss */
+.dd-menu.dd-menu-inverse [role="separator"],
+.dd-menu.dd-menu-inverse .separator {
+  background-color: #45595e;
+}
+
+/* line 98, ../src/scss/_dd-menu.scss */
+.dd-menu [role="separator"],
+.dd-menu .separator {
+  content: '';
+  display: block;
+  height: 2px;
+  background-color: rgba(0, 0, 0, 0.15);
+  margin: 0.5em 0 0.5em 0;
+}
+
+/* line 107, ../src/scss/_dd-menu.scss */
+.dd-menu .dd-items-upwards li.nested-dd-menu>span {
+  bottom: 0;
+  top: initial;
+}
+
+/* line 113, ../src/scss/_dd-menu.scss */
+.dd-menu li.nested-dd-menu {
+  position: relative;
+}
+
+/* line 116, ../src/scss/_dd-menu.scss */
+.dd-menu li.nested-dd-menu>span {
+  position: absolute;
+  top: 0;
+}
+
+.dd-menu {
+  &.long {
+    display: flex;
+    flex-wrap: wrap;
+    max-width: 800px;
+
+    .dd-menu-items {
+      width: 700px;
+
+      .dd-items-left {
+        display: flex;
+        flex-direction: column;
+        max-height: 500px;
+        flex-wrap: wrap;
+        margin: 1.7rem 0 0 !important;
+
+        li {
+          flex: 22%;
+        }
+      }
+    }
+
+    .long-menu-message {
+      padding: 1.5rem;
+      color: #ccc;
+      cursor: pointer;
+    }
+
+    .dropdown-item button {
+      font-size: 0.8rem !important;
+    }
+  }
+
+  .dd-menu-items {
+    margin: 1.1rem 0 0 0 !important;
+
+    ol,
+    ul {
+      border-radius: 0 0 4px 4px;
+
+      li {
+        &:last-of-type {
+          &:hover {
+            border-radius: 0 0 4px 4px;
+          }
+        }
+
+        font-size: 0.9rem;
+      }
+    }
+  }
+}

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -10,7 +10,7 @@
 .swagger-editor-standalone {
   // Standalone preset
   @import "../standalone/styles/main.less";
-  @import (less) "../../node_modules/react-dd-menu/dist/react-dd-menu.css";
+  @import "./_dropdown-menu.less";
 }
 
 // ace editor override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Create `_dropdown-menu.less` from extracted stylesheet within the `react-dd-menu` library. Previously imported this stylesheet directly from the library package.

Update `NOTICE` to give proper credit to this extracted file.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Per npm author notice, `react-dd-menu` package has been deprecated. SwaggerEditor has only been using the package's stylesheet, which has been extracted in this PR.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

local, no visual changes

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [x] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
