### PR TITLE
fix: fix AsyncAPI 2.x Message.traits field lint rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@mui/material": "^5.10.14",
         "@primer/octicons-react": "^17.9.0",
         "@swagger-api/apidom-core": "^0.56.2",
-        "@swagger-api/apidom-ls": "^0.56.2",
+        "@swagger-api/apidom-ls": "^0.56.3",
         "@swagger-api/apidom-ns-api-design-systems": "^0.56.2",
         "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^0.56.2",
         "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^0.56.2",
@@ -5255,9 +5255,9 @@
       }
     },
     "node_modules/@swagger-api/apidom-ls": {
-      "version": "0.56.2",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-ls/0.56.2/9bf7c1228d5fffee76e156b4cd0a88a44a1e1288",
-      "integrity": "sha512-TGwoUy7bdkPc29UjH+rEVR+4h7gEqtbRekFBfZ2pT4YY6gTLtN2sqrePQ4norFDvKaLJ4VstrrmwQpm7fHNftg==",
+      "version": "0.56.3",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-ls/0.56.3/180fbd7bf26d2d4934884b44351fbdd2c1c52ca2",
+      "integrity": "sha512-0mAKDtt2wcrudlvfqXQAbXT+TNOgahWP4zetvOVlU5M4lJ88W9PVRcM7sww5uaKBpm7LQ2E4ZYbVF9MN93K48Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "=7.20.1",
@@ -30115,9 +30115,9 @@
       }
     },
     "@swagger-api/apidom-ls": {
-      "version": "0.56.2",
-      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-ls/0.56.2/9bf7c1228d5fffee76e156b4cd0a88a44a1e1288",
-      "integrity": "sha512-TGwoUy7bdkPc29UjH+rEVR+4h7gEqtbRekFBfZ2pT4YY6gTLtN2sqrePQ4norFDvKaLJ4VstrrmwQpm7fHNftg==",
+      "version": "0.56.3",
+      "resolved": "https://npm.pkg.github.com/download/@swagger-api/apidom-ls/0.56.3/180fbd7bf26d2d4934884b44351fbdd2c1c52ca2",
+      "integrity": "sha512-0mAKDtt2wcrudlvfqXQAbXT+TNOgahWP4zetvOVlU5M4lJ88W9PVRcM7sww5uaKBpm7LQ2E4ZYbVF9MN93K48Q==",
       "requires": {
         "@babel/runtime-corejs3": "=7.20.1",
         "@swagger-api/apidom-core": "^0.56.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@mui/material": "^5.10.14",
     "@primer/octicons-react": "^17.9.0",
     "@swagger-api/apidom-core": "^0.56.2",
-    "@swagger-api/apidom-ls": "^0.56.2",
+    "@swagger-api/apidom-ls": "^0.56.3",
     "@swagger-api/apidom-ns-api-design-systems": "^0.56.2",
     "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^0.56.2",
     "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^0.56.2",


### PR DESCRIPTION
The fix comes via ApiDOM@0.56.3 (apidom-ls)

Refs https://github.com/swagger-api/apidom/releases/tag/v0.56.3

