### PR TITLE
feat(oas3.1): integrate swagger-ui containing OpenAPI3.1 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46170,7 +46170,7 @@
             "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "=0.0.1",
             "@swagger-api/apidom-parser-adapter-yaml-1-2": "=0.0.1",
             "@types/ramda": "=0.28.21",
-            "axios": "=1.2.4",
+            "axios": "npm:-@0.0.1",
             "minimatch": "=6.1.6",
             "process": "=0.11.10",
             "ramda": "=0.28.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "reselect": "^4.1.7",
         "short-unique-id": "^4.4.4",
         "styled-components": "^5.3.6",
-        "swagger-ui-react": "^4.15.5",
+        "swagger-ui-react": "^4.16.0-alpha.3",
         "vscode": "npm:@codingame/monaco-vscode-api@~1.69.13",
         "vscode-languageclient": "^8.0.2",
         "vscode-languageserver-textdocument": "^1.0.8"
@@ -24788,14 +24788,24 @@
       }
     },
     "node_modules/swagger-client": {
-      "version": "3.18.5",
-      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.18.5.tgz",
-      "integrity": "sha512-c0txGDtfQTJnaIBaEKCwtRNcUaaAfj+RXI4QVV9p3WW+AUCQqp4naCjaDNNsOfMkE4ySyhnblbL+jGqAVC7snw==",
+      "version": "3.19.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.19.0-alpha.4.tgz",
+      "integrity": "sha512-Wfi/DHCRNQ2+hBqW/nUptdqU6rDIqa1bzZu6lN50qL6sstEnR0OXPowtVpAW8jVVUF2BzEUMCkyZtQKKTeJO6Q==",
+      "bundleDependencies": [
+        "@swagger-api/apidom-core",
+        "@swagger-api/apidom-reference",
+        "@swagger-api/apidom-ns-openapi-3-1",
+        "@swagger-api/apidom-json-pointer"
+      ],
       "dependencies": {
         "@babel/runtime-corejs3": "^7.11.2",
+        "@swagger-api/apidom-core": "*",
+        "@swagger-api/apidom-json-pointer": "*",
+        "@swagger-api/apidom-ns-openapi-3-1": "*",
+        "@swagger-api/apidom-reference": "*",
         "cookie": "~0.5.0",
         "cross-fetch": "^3.1.5",
-        "deepmerge": "~4.2.2",
+        "deepmerge": "~4.3.0",
         "fast-json-patch": "^3.0.0-1",
         "form-data-encoder": "^1.4.3",
         "formdata-node": "^4.0.0",
@@ -24807,18 +24817,398 @@
         "url": "~0.11.0"
       }
     },
-    "node_modules/swagger-client/node_modules/deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "engines": {
-        "node": ">=0.10.0"
+    "node_modules/swagger-client/node_modules/@swagger-api/apidom-ast": {
+      "version": "0.66.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime-corejs3": "=7.20.7",
+        "@types/ramda": "=0.28.21",
+        "ramda": "=0.28.0",
+        "ramda-adjunct": "=3.4.0",
+        "stampit": "=4.3.2",
+        "unraw": "=2.0.1"
       }
     },
+    "node_modules/swagger-client/node_modules/@swagger-api/apidom-ast/node_modules/@babel/runtime-corejs3": {
+      "version": "7.20.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-js-pure": "^3.25.1",
+        "regenerator-runtime": "^0.13.11"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/swagger-client/node_modules/@swagger-api/apidom-core": {
+      "version": "0.66.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime-corejs3": "=7.20.7",
+        "@swagger-api/apidom-ast": "^0.66.0",
+        "@types/ramda": "=0.28.21",
+        "minim": "=0.23.8",
+        "ramda": "=0.28.0",
+        "ramda-adjunct": "=3.4.0",
+        "short-unique-id": "=4.4.4",
+        "stampit": "=4.3.2"
+      }
+    },
+    "node_modules/swagger-client/node_modules/@swagger-api/apidom-core/node_modules/@babel/runtime-corejs3": {
+      "version": "7.20.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-js-pure": "^3.25.1",
+        "regenerator-runtime": "^0.13.11"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/swagger-client/node_modules/@swagger-api/apidom-json-pointer": {
+      "version": "0.66.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime-corejs3": "=7.20.7",
+        "@swagger-api/apidom-core": "^0.66.0",
+        "ramda": "=0.28.0",
+        "ramda-adjunct": "=3.4.0"
+      }
+    },
+    "node_modules/swagger-client/node_modules/@swagger-api/apidom-json-pointer/node_modules/@babel/runtime-corejs3": {
+      "version": "7.20.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-js-pure": "^3.25.1",
+        "regenerator-runtime": "^0.13.11"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/swagger-client/node_modules/@swagger-api/apidom-ns-asyncapi-2": {
+      "name": "-",
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "UNLICENSED"
+    },
+    "node_modules/swagger-client/node_modules/@swagger-api/apidom-ns-json-schema-draft-4": {
+      "version": "0.66.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime-corejs3": "=7.20.7",
+        "@swagger-api/apidom-core": "^0.66.0",
+        "@types/ramda": "=0.28.21",
+        "ramda": "=0.28.0",
+        "ramda-adjunct": "=3.4.0",
+        "stampit": "=4.3.2"
+      }
+    },
+    "node_modules/swagger-client/node_modules/@swagger-api/apidom-ns-json-schema-draft-4/node_modules/@babel/runtime-corejs3": {
+      "version": "7.20.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-js-pure": "^3.25.1",
+        "regenerator-runtime": "^0.13.11"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/swagger-client/node_modules/@swagger-api/apidom-ns-openapi-3-0": {
+      "version": "0.66.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime-corejs3": "=7.20.7",
+        "@swagger-api/apidom-core": "^0.66.0",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^0.66.0",
+        "@types/ramda": "=0.28.21",
+        "ramda": "=0.28.0",
+        "ramda-adjunct": "=3.4.0",
+        "stampit": "=4.3.2"
+      }
+    },
+    "node_modules/swagger-client/node_modules/@swagger-api/apidom-ns-openapi-3-0/node_modules/@babel/runtime-corejs3": {
+      "version": "7.20.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-js-pure": "^3.25.1",
+        "regenerator-runtime": "^0.13.11"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/swagger-client/node_modules/@swagger-api/apidom-ns-openapi-3-1": {
+      "version": "0.66.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime-corejs3": "=7.20.7",
+        "@swagger-api/apidom-core": "^0.66.0",
+        "@swagger-api/apidom-ns-openapi-3-0": "^0.66.0",
+        "@types/ramda": "=0.28.21",
+        "ramda": "=0.28.0",
+        "ramda-adjunct": "=3.4.0",
+        "stampit": "=4.3.2"
+      }
+    },
+    "node_modules/swagger-client/node_modules/@swagger-api/apidom-ns-openapi-3-1/node_modules/@babel/runtime-corejs3": {
+      "version": "7.20.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-js-pure": "^3.25.1",
+        "regenerator-runtime": "^0.13.11"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/swagger-client/node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json": {
+      "name": "-",
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "UNLICENSED"
+    },
+    "node_modules/swagger-client/node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
+      "name": "-",
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "UNLICENSED"
+    },
+    "node_modules/swagger-client/node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
+      "name": "-",
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "UNLICENSED"
+    },
+    "node_modules/swagger-client/node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
+      "name": "-",
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "UNLICENSED"
+    },
+    "node_modules/swagger-client/node_modules/@swagger-api/apidom-parser-adapter-json": {
+      "name": "-",
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "UNLICENSED"
+    },
+    "node_modules/swagger-client/node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-0": {
+      "name": "-",
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "UNLICENSED"
+    },
+    "node_modules/swagger-client/node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
+      "name": "-",
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "UNLICENSED"
+    },
+    "node_modules/swagger-client/node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": {
+      "name": "-",
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "UNLICENSED"
+    },
+    "node_modules/swagger-client/node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
+      "name": "-",
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "UNLICENSED"
+    },
+    "node_modules/swagger-client/node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2": {
+      "name": "-",
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "UNLICENSED"
+    },
+    "node_modules/swagger-client/node_modules/@swagger-api/apidom-reference": {
+      "version": "0.66.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime-corejs3": "=7.20.7",
+        "@swagger-api/apidom-core": "^0.66.0",
+        "@swagger-api/apidom-json-pointer": "^0.66.0",
+        "@swagger-api/apidom-ns-asyncapi-2": "=0.0.1",
+        "@swagger-api/apidom-ns-openapi-3-0": "^0.66.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.66.0",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "=0.0.1",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "=0.0.1",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "=0.0.1",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "=0.0.1",
+        "@swagger-api/apidom-parser-adapter-json": "=0.0.1",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "=0.0.1",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "=0.0.1",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "=0.0.1",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "=0.0.1",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "=0.0.1",
+        "@types/ramda": "=0.28.21",
+        "axios": "=1.2.4",
+        "minimatch": "=6.1.6",
+        "process": "=0.11.10",
+        "ramda": "=0.28.0",
+        "ramda-adjunct": "=3.4.0",
+        "stampit": "=4.3.2"
+      }
+    },
+    "node_modules/swagger-client/node_modules/@swagger-api/apidom-reference/node_modules/@babel/runtime-corejs3": {
+      "version": "7.20.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-js-pure": "^3.25.1",
+        "regenerator-runtime": "^0.13.11"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/swagger-client/node_modules/@types/ramda": {
+      "version": "0.28.21",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ts-toolbelt": "^6.15.1"
+      }
+    },
+    "node_modules/swagger-client/node_modules/axios": {
+      "name": "-",
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "UNLICENSED"
+    },
+    "node_modules/swagger-client/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/swagger-client/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/swagger-client/node_modules/core-js-pure": {
+      "version": "3.27.2",
+      "hasInstallScript": true,
+      "inBundle": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/swagger-client/node_modules/lodash": {
+      "version": "4.17.21",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/swagger-client/node_modules/minim": {
+      "version": "0.23.8",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.15.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/swagger-client/node_modules/minimatch": {
+      "version": "6.1.6",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/swagger-client/node_modules/process": {
+      "version": "0.11.10",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/swagger-client/node_modules/ramda": {
+      "version": "0.28.0",
+      "inBundle": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ramda"
+      }
+    },
+    "node_modules/swagger-client/node_modules/ramda-adjunct": {
+      "version": "3.4.0",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ramda-adjunct"
+      },
+      "peerDependencies": {
+        "ramda": ">= 0.28.0 <= 0.28.0"
+      }
+    },
+    "node_modules/swagger-client/node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/swagger-client/node_modules/short-unique-id": {
+      "version": "4.4.4",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "short-unique-id": "bin/short-unique-id",
+        "suid": "bin/short-unique-id"
+      }
+    },
+    "node_modules/swagger-client/node_modules/stampit": {
+      "version": "4.3.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/swagger-client/node_modules/ts-toolbelt": {
+      "version": "6.15.5",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/swagger-client/node_modules/unraw": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/swagger-ui-react": {
-      "version": "4.15.5",
-      "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-4.15.5.tgz",
-      "integrity": "sha512-jt2g6cDt3wOsc+1YQv4D86V4K659Xs1/pbhjYWlgNfjZB0TSN601MASWxbP+65U0iPpsJTpF7EmRzAunTOVs8Q==",
+      "version": "4.16.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-4.16.0-alpha.3.tgz",
+      "integrity": "sha512-GmZGxuLzfMgIH9GaX7malbwrmN0oVQXA4deAo/79CLAQ4Z1PsWNCpbYNZEb0Zzw1us/OBZDbpcFa/hruZSl1Cg==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.18.9",
         "@braintree/sanitize-url": "=6.0.0",
@@ -24849,7 +25239,7 @@
         "reselect": "^4.1.5",
         "serialize-error": "^8.1.0",
         "sha.js": "^2.4.11",
-        "swagger-client": "^3.18.5",
+        "swagger-client": "=3.19.0-alpha.4",
         "url-parse": "^1.5.8",
         "xml": "=1.0.1",
         "xml-but-prettier": "^1.0.1",
@@ -45558,14 +45948,18 @@
       }
     },
     "swagger-client": {
-      "version": "3.18.5",
-      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.18.5.tgz",
-      "integrity": "sha512-c0txGDtfQTJnaIBaEKCwtRNcUaaAfj+RXI4QVV9p3WW+AUCQqp4naCjaDNNsOfMkE4ySyhnblbL+jGqAVC7snw==",
+      "version": "3.19.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.19.0-alpha.4.tgz",
+      "integrity": "sha512-Wfi/DHCRNQ2+hBqW/nUptdqU6rDIqa1bzZu6lN50qL6sstEnR0OXPowtVpAW8jVVUF2BzEUMCkyZtQKKTeJO6Q==",
       "requires": {
         "@babel/runtime-corejs3": "^7.11.2",
+        "@swagger-api/apidom-core": "*",
+        "@swagger-api/apidom-json-pointer": "*",
+        "@swagger-api/apidom-ns-openapi-3-1": "*",
+        "@swagger-api/apidom-reference": "*",
         "cookie": "~0.5.0",
         "cross-fetch": "^3.1.5",
-        "deepmerge": "~4.2.2",
+        "deepmerge": "~4.3.0",
         "fast-json-patch": "^3.0.0-1",
         "form-data-encoder": "^1.4.3",
         "formdata-node": "^4.0.0",
@@ -45577,17 +45971,306 @@
         "url": "~0.11.0"
       },
       "dependencies": {
-        "deepmerge": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-          "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+        "@swagger-api/apidom-ast": {
+          "version": "0.66.0",
+          "bundled": true,
+          "requires": {
+            "@babel/runtime-corejs3": "=7.20.7",
+            "@types/ramda": "=0.28.21",
+            "ramda": "=0.28.0",
+            "ramda-adjunct": "=3.4.0",
+            "stampit": "=4.3.2",
+            "unraw": "=2.0.1"
+          },
+          "dependencies": {
+            "@babel/runtime-corejs3": {
+              "version": "7.20.7",
+              "bundled": true,
+              "requires": {
+                "core-js-pure": "^3.25.1",
+                "regenerator-runtime": "^0.13.11"
+              }
+            }
+          }
+        },
+        "@swagger-api/apidom-core": {
+          "version": "0.66.0",
+          "bundled": true,
+          "requires": {
+            "@babel/runtime-corejs3": "=7.20.7",
+            "@swagger-api/apidom-ast": "^0.66.0",
+            "@types/ramda": "=0.28.21",
+            "minim": "=0.23.8",
+            "ramda": "=0.28.0",
+            "ramda-adjunct": "=3.4.0",
+            "short-unique-id": "=4.4.4",
+            "stampit": "=4.3.2"
+          },
+          "dependencies": {
+            "@babel/runtime-corejs3": {
+              "version": "7.20.7",
+              "bundled": true,
+              "requires": {
+                "core-js-pure": "^3.25.1",
+                "regenerator-runtime": "^0.13.11"
+              }
+            }
+          }
+        },
+        "@swagger-api/apidom-json-pointer": {
+          "version": "0.66.0",
+          "bundled": true,
+          "requires": {
+            "@babel/runtime-corejs3": "=7.20.7",
+            "@swagger-api/apidom-core": "^0.66.0",
+            "ramda": "=0.28.0",
+            "ramda-adjunct": "=3.4.0"
+          },
+          "dependencies": {
+            "@babel/runtime-corejs3": {
+              "version": "7.20.7",
+              "bundled": true,
+              "requires": {
+                "core-js-pure": "^3.25.1",
+                "regenerator-runtime": "^0.13.11"
+              }
+            }
+          }
+        },
+        "@swagger-api/apidom-ns-asyncapi-2": {
+          "version": "npm:-@0.0.1",
+          "bundled": true
+        },
+        "@swagger-api/apidom-ns-json-schema-draft-4": {
+          "version": "0.66.0",
+          "bundled": true,
+          "requires": {
+            "@babel/runtime-corejs3": "=7.20.7",
+            "@swagger-api/apidom-core": "^0.66.0",
+            "@types/ramda": "=0.28.21",
+            "ramda": "=0.28.0",
+            "ramda-adjunct": "=3.4.0",
+            "stampit": "=4.3.2"
+          },
+          "dependencies": {
+            "@babel/runtime-corejs3": {
+              "version": "7.20.7",
+              "bundled": true,
+              "requires": {
+                "core-js-pure": "^3.25.1",
+                "regenerator-runtime": "^0.13.11"
+              }
+            }
+          }
+        },
+        "@swagger-api/apidom-ns-openapi-3-0": {
+          "version": "0.66.0",
+          "bundled": true,
+          "requires": {
+            "@babel/runtime-corejs3": "=7.20.7",
+            "@swagger-api/apidom-core": "^0.66.0",
+            "@swagger-api/apidom-ns-json-schema-draft-4": "^0.66.0",
+            "@types/ramda": "=0.28.21",
+            "ramda": "=0.28.0",
+            "ramda-adjunct": "=3.4.0",
+            "stampit": "=4.3.2"
+          },
+          "dependencies": {
+            "@babel/runtime-corejs3": {
+              "version": "7.20.7",
+              "bundled": true,
+              "requires": {
+                "core-js-pure": "^3.25.1",
+                "regenerator-runtime": "^0.13.11"
+              }
+            }
+          }
+        },
+        "@swagger-api/apidom-ns-openapi-3-1": {
+          "version": "0.66.0",
+          "bundled": true,
+          "requires": {
+            "@babel/runtime-corejs3": "=7.20.7",
+            "@swagger-api/apidom-core": "^0.66.0",
+            "@swagger-api/apidom-ns-openapi-3-0": "^0.66.0",
+            "@types/ramda": "=0.28.21",
+            "ramda": "=0.28.0",
+            "ramda-adjunct": "=3.4.0",
+            "stampit": "=4.3.2"
+          },
+          "dependencies": {
+            "@babel/runtime-corejs3": {
+              "version": "7.20.7",
+              "bundled": true,
+              "requires": {
+                "core-js-pure": "^3.25.1",
+                "regenerator-runtime": "^0.13.11"
+              }
+            }
+          }
+        },
+        "@swagger-api/apidom-parser-adapter-api-design-systems-json": {
+          "version": "npm:-@0.0.1",
+          "bundled": true
+        },
+        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
+          "version": "npm:-@0.0.1",
+          "bundled": true
+        },
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
+          "version": "npm:-@0.0.1",
+          "bundled": true
+        },
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
+          "version": "npm:-@0.0.1",
+          "bundled": true
+        },
+        "@swagger-api/apidom-parser-adapter-json": {
+          "version": "npm:-@0.0.1",
+          "bundled": true
+        },
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": {
+          "version": "npm:-@0.0.1",
+          "bundled": true
+        },
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
+          "version": "npm:-@0.0.1",
+          "bundled": true
+        },
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": {
+          "version": "npm:-@0.0.1",
+          "bundled": true
+        },
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
+          "version": "npm:-@0.0.1",
+          "bundled": true
+        },
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": {
+          "version": "npm:-@0.0.1",
+          "bundled": true
+        },
+        "@swagger-api/apidom-reference": {
+          "version": "0.66.0",
+          "bundled": true,
+          "requires": {
+            "@babel/runtime-corejs3": "=7.20.7",
+            "@swagger-api/apidom-core": "^0.66.0",
+            "@swagger-api/apidom-json-pointer": "^0.66.0",
+            "@swagger-api/apidom-ns-asyncapi-2": "=0.0.1",
+            "@swagger-api/apidom-ns-openapi-3-0": "^0.66.0",
+            "@swagger-api/apidom-ns-openapi-3-1": "^0.66.0",
+            "@swagger-api/apidom-parser-adapter-api-design-systems-json": "=0.0.1",
+            "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "=0.0.1",
+            "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "=0.0.1",
+            "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "=0.0.1",
+            "@swagger-api/apidom-parser-adapter-json": "=0.0.1",
+            "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "=0.0.1",
+            "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "=0.0.1",
+            "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "=0.0.1",
+            "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "=0.0.1",
+            "@swagger-api/apidom-parser-adapter-yaml-1-2": "=0.0.1",
+            "@types/ramda": "=0.28.21",
+            "axios": "=1.2.4",
+            "minimatch": "=6.1.6",
+            "process": "=0.11.10",
+            "ramda": "=0.28.0",
+            "ramda-adjunct": "=3.4.0",
+            "stampit": "=4.3.2"
+          },
+          "dependencies": {
+            "@babel/runtime-corejs3": {
+              "version": "7.20.7",
+              "bundled": true,
+              "requires": {
+                "core-js-pure": "^3.25.1",
+                "regenerator-runtime": "^0.13.11"
+              }
+            }
+          }
+        },
+        "@types/ramda": {
+          "version": "0.28.21",
+          "bundled": true,
+          "requires": {
+            "ts-toolbelt": "^6.15.1"
+          }
+        },
+        "axios": {
+          "version": "npm:-@0.0.1",
+          "bundled": true
+        },
+        "balanced-match": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "core-js-pure": {
+          "version": "3.27.2",
+          "bundled": true
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "bundled": true
+        },
+        "minim": {
+          "version": "0.23.8",
+          "bundled": true,
+          "requires": {
+            "lodash": "^4.15.0"
+          }
+        },
+        "minimatch": {
+          "version": "6.1.6",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "process": {
+          "version": "0.11.10",
+          "bundled": true
+        },
+        "ramda": {
+          "version": "0.28.0",
+          "bundled": true
+        },
+        "ramda-adjunct": {
+          "version": "3.4.0",
+          "bundled": true,
+          "requires": {}
+        },
+        "regenerator-runtime": {
+          "version": "0.13.11",
+          "bundled": true
+        },
+        "short-unique-id": {
+          "version": "4.4.4",
+          "bundled": true
+        },
+        "stampit": {
+          "version": "4.3.2",
+          "bundled": true
+        },
+        "ts-toolbelt": {
+          "version": "6.15.5",
+          "bundled": true
+        },
+        "unraw": {
+          "version": "2.0.1",
+          "bundled": true
         }
       }
     },
     "swagger-ui-react": {
-      "version": "4.15.5",
-      "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-4.15.5.tgz",
-      "integrity": "sha512-jt2g6cDt3wOsc+1YQv4D86V4K659Xs1/pbhjYWlgNfjZB0TSN601MASWxbP+65U0iPpsJTpF7EmRzAunTOVs8Q==",
+      "version": "4.16.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-4.16.0-alpha.3.tgz",
+      "integrity": "sha512-GmZGxuLzfMgIH9GaX7malbwrmN0oVQXA4deAo/79CLAQ4Z1PsWNCpbYNZEb0Zzw1us/OBZDbpcFa/hruZSl1Cg==",
       "requires": {
         "@babel/runtime-corejs3": "^7.18.9",
         "@braintree/sanitize-url": "=6.0.0",
@@ -45618,7 +46301,7 @@
         "reselect": "^4.1.5",
         "serialize-error": "^8.1.0",
         "sha.js": "^2.4.11",
-        "swagger-client": "^3.18.5",
+        "swagger-client": "=3.19.0-alpha.4",
         "url-parse": "^1.5.8",
         "xml": "=1.0.1",
         "xml-but-prettier": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -127,5 +127,12 @@
     "source-map-explorer": "^2.5.3",
     "start-server-and-test": "^1.15.3",
     "web-vitals": "^3.1.1"
+  },
+  "overrides": {
+    "swagger-client": {
+      "@swagger-api/apidom-reference": {
+        "axios": "npm:-@0.0.1"
+      }
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "reselect": "^4.1.7",
     "short-unique-id": "^4.4.4",
     "styled-components": "^5.3.6",
-    "swagger-ui-react": "^4.15.5",
+    "swagger-ui-react": "^4.16.0-alpha.3",
     "vscode": "npm:@codingame/monaco-vscode-api@~1.69.13",
     "vscode-languageclient": "^8.0.2",
     "vscode-languageserver-textdocument": "^1.0.8"

--- a/src/plugins/editor-preview-swagger-ui/wrap-components/EditorPreviewWrapper.jsx
+++ b/src/plugins/editor-preview-swagger-ui/wrap-components/EditorPreviewWrapper.jsx
@@ -4,14 +4,17 @@ import PropTypes from 'prop-types';
 const EditorPreviewWrapper = (Original, system) => {
   const EditorPreview = ({ getComponent, editorSelectors }) => {
     const EditorPreviewSwaggerUI = getComponent('EditorPreviewSwaggerUI', true);
-    const EditorPreviewSwaggerUIFallback = getComponent('EditorPreviewSwaggerUIFallback', true);
+    /**
+     * Render `EditorPreviewSwaggerUIFallback` if SwaggerUI does not support targeted OpenAPI version
+     */
+    // const EditorPreviewSwaggerUIFallback = getComponent('EditorPreviewSwaggerUIFallback', true);
     const isOpenAPI = editorSelectors.selectIsContentTypeOpenAPI();
     const isOpenAPI31 = editorSelectors.selectIsContentTypeOpenAPI31x();
     if (isOpenAPI && !isOpenAPI31) {
       return <EditorPreviewSwaggerUI />;
     }
     if (isOpenAPI && isOpenAPI31) {
-      return <EditorPreviewSwaggerUIFallback />;
+      return <EditorPreviewSwaggerUI />;
     }
     return (
       <Original {...system} /> // eslint-disable-line react/jsx-props-no-spreading


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

- update `EditorPreviewWrapper` to render SwaggerUI if definition is OpenAPI3.1. Previously would render a fallback component
- update `swagger-ui-react` dependency

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

`swagger-ui@4.16.0-alpha.3` and `swagger-ui-react@4.16.0-alpha.3` now supports OpenAPI 3.1 via `apidom`

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

local


### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
