### PR TITLE
ci(release): add --legacy-peer-deps option for npm

### DIFF
--- a/release/.release-it.json
+++ b/release/.release-it.json
@@ -2,8 +2,8 @@
   "hooks": {
     "before:bump": [
       "./release/check-for-breaking-changes.sh ${latestVersion} ${version}",
-      "npm update swagger-client",
-      "npm update swagger-ui",
+      "npm update swagger-client --legacy-peer-deps",
+      "npm update swagger-ui --legacy-peer-deps",
       "npm run lint-errors",
       "npm run test:unit-mocha",
       "npm run test:unit-jest"


### PR DESCRIPTION
This allows to use lockfileVersion=2 in package-lock.json file.

Refs #2966

