### PR TITLE
refactor(language-apidom): enhance dereference monaco action

### DIFF
--- a/src/plugins/editor-monaco-language-apidom/after-load.js
+++ b/src/plugins/editor-monaco-language-apidom/after-load.js
@@ -8,7 +8,7 @@ const makeAfterLoad =
   (system) => {
     if (isLanguageRegistered()) return;
 
-    lazyMonacoContribution({ createData });
+    lazyMonacoContribution({ createData, system });
     system.editorActions.setLanguage(apidomDefaults.getLanguageId());
   };
 

--- a/src/plugins/editor-monaco-language-apidom/language/actions/dereference.js
+++ b/src/plugins/editor-monaco-language-apidom/language/actions/dereference.js
@@ -1,17 +1,31 @@
+import YAML from 'js-yaml';
+
 import { getWorker } from '../apidom-mode.js';
 
-const dereferenceActionDescriptor = {
+const createDereferenceActionDescriptor = ({ getSystem }) => ({
   id: 'swagger.editor.apidomDereference',
   label: 'Resolve document',
   async run(editor) {
+    const system = getSystem();
+    const isContentJSON = system.editorSelectors.selectIsContentFormatJSON();
+    const isContentYAML = system.editorSelectors.selectIsContentFormatYAML();
+
+    if (!isContentJSON && !isContentYAML) return; // nothing to do here
+
     const model = editor.getModel();
     const worker = await getWorker()(model.uri);
     const dereferenced = await worker.doDeref(model.uri.toString(), {
       baseURI: globalThis.document.baseURI || globalThis.location.href,
+      format: isContentJSON ? 0 : isContentYAML ? 1 : 'unknown', // eslint-disable-line no-nested-ternary
     });
 
-    editor.setValue(dereferenced);
+    if (isContentYAML) {
+      const nicelyFormattedYAML = YAML.dump(YAML.load(dereferenced));
+      editor.setValue(nicelyFormattedYAML);
+    } else if (isContentJSON) {
+      editor.setValue(dereferenced);
+    }
   },
-};
+});
 
-export default dereferenceActionDescriptor;
+export default createDereferenceActionDescriptor;

--- a/src/plugins/editor-monaco-language-apidom/language/monaco.contribution.js
+++ b/src/plugins/editor-monaco-language-apidom/language/monaco.contribution.js
@@ -4,7 +4,7 @@ import { ModesRegistry } from 'monaco-editor/esm/vs/editor/common/languages/mode
 
 import * as apidom from './apidom.js';
 import { setupMode } from './apidom-mode.js';
-import dereferenceActionDescriptor from './actions/dereference.js';
+import createDereferenceActionDescriptor from './actions/dereference.js';
 import jsonPointerPositionActionDescriptor from './actions/json-pointer-position.js';
 
 export { getWorker } from './apidom-mode.js';
@@ -65,7 +65,7 @@ export const isLanguageRegistered = () => {
   return languages.includes(apidom.languageId);
 };
 
-const lazyMonacoContribution = ({ createData }) => {
+const lazyMonacoContribution = ({ createData, system }) => {
   const disposables = [];
 
   // register apidom language
@@ -98,9 +98,11 @@ const lazyMonacoContribution = ({ createData }) => {
     monaco.editor.onDidCreateEditor((editor) => {
       disposables.push(
         monaco.editor.onDidCreateModel(() => {
+          const dereferenceActionDescriptor = createDereferenceActionDescriptor(system);
           if (!editor.getAction(dereferenceActionDescriptor.id)) {
             disposables.push(editor.addAction(dereferenceActionDescriptor));
           }
+
           disposables.push(editor.addAction(jsonPointerPositionActionDescriptor));
         })
       );

--- a/src/plugins/editor-preview-asyncapi/util/raml-1-0-parser.js
+++ b/src/plugins/editor-preview-asyncapi/util/raml-1-0-parser.js
@@ -1,4 +1,4 @@
-import yaml from 'js-yaml';
+import YAML from 'js-yaml';
 
 /* eslint-disable no-param-reassign */
 
@@ -6,7 +6,7 @@ export async function parse({ message, defaultSchemaFormat }) {
   try {
     let { payload } = message;
     if (typeof payload === 'object') {
-      payload = yaml.dump(payload);
+      payload = YAML.dump(payload);
     }
 
     message['x-parser-original-schema-format'] = message.schemaFormat || defaultSchemaFormat;


### PR DESCRIPTION
- infere format (JSON/YAML) from editor content
- do nothing on unknown format
- use js-yaml library to pretty-format the dereferenced YAML
