### PR TITLE
feat(editor-preview-swagger-ui): render OpenAPI 3.1 Schema Objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "reselect": "^4.1.7",
         "short-unique-id": "^4.4.4",
         "styled-components": "^5.3.9",
-        "swagger-ui-react": "^5.0.0-alpha.6",
+        "swagger-ui-react": "^5.0.0-alpha.7",
         "vscode": "npm:@codingame/monaco-vscode-api@~1.76.7",
         "vscode-languageclient": "^8.1.0",
         "vscode-languageserver-textdocument": "^1.0.8"
@@ -25124,9 +25124,9 @@
       }
     },
     "node_modules/swagger-ui-react": {
-      "version": "5.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-5.0.0-alpha.6.tgz",
-      "integrity": "sha512-x18UkOT8BNRFcgKH0YZ7uCNcIf5KKnHYUzB76kpv8sP+cUvQInqWb76q7fugogcjLcN/GPpPkvnSRVTen+TDdQ==",
+      "version": "5.0.0-alpha.7",
+      "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-5.0.0-alpha.7.tgz",
+      "integrity": "sha512-eCy3jqMQ7fOqDAIFa3SI+VGBzNkyINkOtm2O/szxTarXQq/Zly95hxSbdA9tV0dkH+g0rMMf/lXdFrvXwyNxhw==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.21.0",
         "@braintree/sanitize-url": "=6.0.2",
@@ -46173,9 +46173,9 @@
       }
     },
     "swagger-ui-react": {
-      "version": "5.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-5.0.0-alpha.6.tgz",
-      "integrity": "sha512-x18UkOT8BNRFcgKH0YZ7uCNcIf5KKnHYUzB76kpv8sP+cUvQInqWb76q7fugogcjLcN/GPpPkvnSRVTen+TDdQ==",
+      "version": "5.0.0-alpha.7",
+      "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-5.0.0-alpha.7.tgz",
+      "integrity": "sha512-eCy3jqMQ7fOqDAIFa3SI+VGBzNkyINkOtm2O/szxTarXQq/Zly95hxSbdA9tV0dkH+g0rMMf/lXdFrvXwyNxhw==",
       "requires": {
         "@babel/runtime-corejs3": "^7.21.0",
         "@braintree/sanitize-url": "=6.0.2",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "reselect": "^4.1.7",
     "short-unique-id": "^4.4.4",
     "styled-components": "^5.3.9",
-    "swagger-ui-react": "^5.0.0-alpha.6",
+    "swagger-ui-react": "^5.0.0-alpha.7",
     "vscode": "npm:@codingame/monaco-vscode-api@~1.76.7",
     "vscode-languageclient": "^8.1.0",
     "vscode-languageserver-textdocument": "^1.0.8"


### PR DESCRIPTION
OpenAPI 3.1.0 components.schemas are rendered using new JSON Schema 2020-12 capable renderer.

Supported vocabularies:
  - [x] Core
  - [ ] Validation
  - [ ] OpenAPI 3.1.0 base

This rendering support comes via swagger-ui-react@5.0.0-alpha.7.

Refs https://github.com/swagger-api/swagger-ui/releases/tag/v5.0.0-alpha.7
