### PR TITLE
fix(language-apidom): aprovide document links with non-empty ranges

### DIFF
--- a/src/plugins/editor-monaco-language-apidom/language/adapters/DocumentLinkAdapter.js
+++ b/src/plugins/editor-monaco-language-apidom/language/adapters/DocumentLinkAdapter.js
@@ -13,8 +13,11 @@ class DocumentLinkAdapter extends Adapter {
 
   async provideDocumentLinks(vscodeDocument) {
     const links = await this.#getLinks(vscodeDocument);
+    const linksWithNonEmptyRanges = links.filter(
+      (link) => !this.protocolConverter.asRange(link.range).isEmpty
+    );
 
-    return this.protocolConverter.asDocumentLinks(links);
+    return this.protocolConverter.asDocumentLinks(linksWithNonEmptyRanges);
   }
 
   // eslint-disable-next-line class-methods-use-this


### PR DESCRIPTION
Refs #3216


When converting `Document Links` with protocol converter which contains empty ranges, the error will be thrown. This fix avoids the error being thrown.