### PR TITLE
fix: select editor instances in deterministic way

### DIFF
--- a/src/plugins/editor-monaco-language-apidom/actions/get-json-pointer-position.js
+++ b/src/plugins/editor-monaco-language-apidom/actions/get-json-pointer-position.js
@@ -1,5 +1,3 @@
-import * as monaco from 'monaco-editor';
-
 export const EDITOR_MONACO_LANGUAGE_APIDOM_GET_JSON_POINTER_POSITION_STARTED =
   'editor_monaco_language_apidom_get_json_pointer_position_started';
 
@@ -28,12 +26,12 @@ export const getJsonPointerPositionFailure = ({ error, jsonPointer }) => ({
 });
 
 export const getJsonPointerPosition = (jsonPointer) => async (system) => {
-  const { editorActions, fn } = system;
+  const { editorActions, editorSelectors, fn } = system;
 
   editorActions.getJsonPointerPositionStarted({ jsonPointer });
 
   try {
-    const [editor] = monaco.editor.getEditors();
+    const editor = editorSelectors.selectEditor();
     const model = editor.getModel();
     const worker = await fn.getApiDOMWorker()(model.uri);
     const { line, character } = await worker.getJsonPointerPosition(

--- a/src/plugins/editor-monaco/actions/set-position.js
+++ b/src/plugins/editor-monaco/actions/set-position.js
@@ -1,5 +1,3 @@
-import * as monaco from 'monaco-editor';
-
 export const EDITOR_SET_POSITION_STARTED = 'editor_set_position_started';
 export const EDITOR_SET_POSITION_SUCCESS = 'editor_set_position_success';
 export const EDITOR_SET_POSITION_FAILURE = 'editor_set_position_failure';
@@ -24,12 +22,12 @@ export const setPositionFailure = ({ lineNumber, column, error }) => ({
 export const setPosition =
   ({ lineNumber = 0, column = 0 } = {}) =>
   (system) => {
-    const { editorActions } = system;
+    const { editorActions, editorSelectors } = system;
 
     editorActions.setPositionStarted({ lineNumber, column });
 
     try {
-      const [editor] = monaco.editor.getEditors();
+      const editor = editorSelectors.selectEditor();
 
       editor.revealPositionNearTop({ lineNumber, column });
       editor.setPosition({ lineNumber, column });

--- a/src/plugins/editor-monaco/components/MonacoEditor/MonacoEditor.jsx
+++ b/src/plugins/editor-monaco/components/MonacoEditor/MonacoEditor.jsx
@@ -137,9 +137,14 @@ const MonacoEditor = ({
   useEffect(() => {
     if (!isEditorReady) return undefined;
 
-    const disposable = monaco.editor.onDidChangeMarkers(() => {
-      const markers = monaco.editor.getModelMarkers();
-      onEditorMarkersDidChange(markers);
+    const disposable = monaco.editor.onDidChangeMarkers((uris) => {
+      const { uri: currentModelUri } = editorRef.current.getModel();
+      const hasCurrentModelChanged = uris.find((uri) => String(uri) === String(currentModelUri));
+
+      if (hasCurrentModelChanged) {
+        const markers = monaco.editor.getModelMarkers({ resource: currentModelUri });
+        onEditorMarkersDidChange(markers);
+      }
     });
 
     return () => {

--- a/src/plugins/editor-monaco/index.js
+++ b/src/plugins/editor-monaco/index.js
@@ -18,7 +18,7 @@ import {
 } from './actions/set-position.js';
 import { setTheme } from './actions/set-theme.js';
 import reducers from './reducers.js';
-import { selectTheme, selectMarkers, selectLanguage } from './selectors.js';
+import { selectTheme, selectMarkers, selectLanguage, selectEditor } from './selectors.js';
 import afterLoad from './after-load.js';
 
 const EditorMonacoPlugin = () => ({
@@ -56,6 +56,7 @@ const EditorMonacoPlugin = () => ({
         selectTheme,
         selectMarkers,
         selectLanguage,
+        selectEditor,
       },
     },
   },

--- a/src/plugins/editor-monaco/reducers.js
+++ b/src/plugins/editor-monaco/reducers.js
@@ -27,6 +27,24 @@ const reducers = {
   [EDITOR_SET_LANGUAGE]: (state, action) => {
     return state.set('language', action.payload);
   },
+  // this action type comes from editor-textarea plugin
+  editor_setup: (state, action) => {
+    if (!action.meta.includes('monaco')) {
+      return state;
+    }
+    return state.set('id', action.payload.getId());
+  },
+  // this action type comes from editor-textarea plugin
+  editor_tear_down: (state, action) => {
+    if (!action.meta.includes('monaco')) {
+      return state;
+    }
+    if (state.get('id') !== action.payload.getId()) {
+      return state;
+    }
+
+    return state.delete('id');
+  },
 };
 
 export default reducers;

--- a/src/plugins/editor-monaco/selectors.js
+++ b/src/plugins/editor-monaco/selectors.js
@@ -1,3 +1,4 @@
+import * as monaco from 'monaco-editor';
 import { createSelector } from 'reselect';
 import { List } from 'immutable';
 
@@ -9,3 +10,8 @@ export const selectMarkers = createSelector(
 );
 
 export const selectLanguage = (state) => state.get('language', 'plaintext');
+
+export const selectEditor = () => (system) => {
+  const id = system.editorSelectors.selectId();
+  return monaco.editor.getEditors().find((editor) => editor.getId() === id);
+};

--- a/src/plugins/editor-textarea/components/TextareaEditor/TextareaEditor.jsx
+++ b/src/plugins/editor-textarea/components/TextareaEditor/TextareaEditor.jsx
@@ -1,8 +1,12 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
+// @TODO(vladimir.gorej@gmail.com): this can be replaced by React.useId in React@18
+import { useId } from '../../hooks.js';
+
 const TextareaEditor = ({ isReadOnly, editorActions, editorSelectors, useEditorLifecycle }) => {
   const content = editorSelectors.selectContent();
+  const id = useId();
   const editorRef = useEditorLifecycle('textarea');
   const [value, setValue] = useState(content);
 
@@ -21,6 +25,7 @@ const TextareaEditor = ({ isReadOnly, editorActions, editorSelectors, useEditorL
 
   return (
     <textarea
+      id={id}
       ref={editorRef}
       readOnly={isReadOnly}
       className="swagger-editor__editor-textarea"

--- a/src/plugins/editor-textarea/hooks.js
+++ b/src/plugins/editor-textarea/hooks.js
@@ -1,7 +1,6 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useResizeDetector } from 'react-resize-detector';
 
-// eslint-disable-next-line import/prefer-default-export
 export const makeUseEditorLifecycle = (getSystem) => (implementation) => {
   const { editorActions } = getSystem();
   const editorRef = useRef(null);
@@ -33,4 +32,10 @@ export const useElementResize = ({ eventName }) => {
   });
 
   return ref;
+};
+
+export const useId = () => {
+  const randomNumber = Math.floor(Math.random() * 10000000);
+  const [id] = useState(String(randomNumber));
+  return id;
 };

--- a/src/plugins/editor-textarea/index.js
+++ b/src/plugins/editor-textarea/index.js
@@ -5,7 +5,7 @@ import EditorPaneBarRight from './components/EditorPaneBars/EditorPaneBarRight.j
 import EditorPaneBarBottom from './components/EditorPaneBars/EditorPaneBarBottom.jsx';
 import EditorPaneBarLeft from './components/EditorPaneBars/EditorPaneBarLeft.jsx';
 import { editorSetup, editorTearDown, setContent, clearContent } from './actions.js';
-import { selectContent } from './selectors.js';
+import { selectContent, selectId, selectEditor } from './selectors.js';
 import reducers from './reducers.js';
 import {
   editorSetup as editorSetupWrap,
@@ -47,6 +47,8 @@ const EditorTextareaPlugin = ({ getSystem }) => ({
       },
       selectors: {
         selectContent,
+        selectId,
+        selectEditor,
       },
       reducers,
     },

--- a/src/plugins/editor-textarea/reducers.js
+++ b/src/plugins/editor-textarea/reducers.js
@@ -1,13 +1,29 @@
-import { EDITOR_SET_CONTENT } from './actions.js';
+import { EDITOR_SET_CONTENT, EDITOR_SETUP, EDITOR_TEAR_DOWN } from './actions.js';
 
 export const initialState = {
   content: '',
-  contentVersion: 1,
+  id: null,
 };
 
 const reducers = {
   [EDITOR_SET_CONTENT]: (state, action) => {
     return state.set('content', action.payload);
+  },
+  [EDITOR_SETUP]: (state, action) => {
+    if (!action.meta.includes('textarea')) {
+      return state;
+    }
+    return state.set('id', action.payload.id);
+  },
+  [EDITOR_TEAR_DOWN]: (state, action) => {
+    if (!action.meta.includes('textarea')) {
+      return state;
+    }
+    if (state.get('id') !== action.payload.id) {
+      return state;
+    }
+
+    return state.delete('id');
   },
 };
 

--- a/src/plugins/editor-textarea/selectors.js
+++ b/src/plugins/editor-textarea/selectors.js
@@ -1,4 +1,11 @@
 import { initialState } from './reducers.js';
 
 // eslint-disable-next-line import/prefer-default-export
-export const selectContent = (state) => state.get('content') || initialState.content;
+export const selectContent = (state) => state.get('content', initialState.content);
+
+export const selectId = (state) => state.get('id', initialState.id);
+
+export const selectEditor = () => (system) => {
+  const id = system.editorSelectors.selectId();
+  return document.getElementById(id);
+};


### PR DESCRIPTION
If multiple <SwaggerEditor /> components are utilized on the same page, each of them should work independently without affecting the other ones.
