### PR TITLE
feat(preview-swagger-ui): render JSON Schema 2020-12 in OpenAPI 3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "reselect": "^4.1.7",
         "short-unique-id": "^4.4.4",
         "styled-components": "^5.3.10",
-        "swagger-ui-react": "^5.0.0-alpha.10",
+        "swagger-ui-react": "^5.0.0-alpha.12",
         "vscode": "npm:@codingame/monaco-vscode-api@~1.76.7",
         "vscode-languageclient": "^8.1.0",
         "vscode-languageserver-textdocument": "^1.0.8"
@@ -25267,9 +25267,9 @@
       }
     },
     "node_modules/swagger-ui-react": {
-      "version": "5.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-5.0.0-alpha.10.tgz",
-      "integrity": "sha512-DpHPRT2GYfvOPpsYru8f8GUn3c1XpdCglJ3t+cXa+zy8mJlOUReA9zNAbRT0wTni+RCxcQ76YcW1Plw9XiFKrg==",
+      "version": "5.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-5.0.0-alpha.12.tgz",
+      "integrity": "sha512-KLSz7jfCaVOButHVjmPFLm4bwq1n3gcEnArms0NmWEEDBsc6XgvuV2n2o+/WLD9NtNX565iVLvOfd6AIwP8yag==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.21.5",
         "@braintree/sanitize-url": "=6.0.2",
@@ -46442,9 +46442,9 @@
       }
     },
     "swagger-ui-react": {
-      "version": "5.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-5.0.0-alpha.10.tgz",
-      "integrity": "sha512-DpHPRT2GYfvOPpsYru8f8GUn3c1XpdCglJ3t+cXa+zy8mJlOUReA9zNAbRT0wTni+RCxcQ76YcW1Plw9XiFKrg==",
+      "version": "5.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-5.0.0-alpha.12.tgz",
+      "integrity": "sha512-KLSz7jfCaVOButHVjmPFLm4bwq1n3gcEnArms0NmWEEDBsc6XgvuV2n2o+/WLD9NtNX565iVLvOfd6AIwP8yag==",
       "requires": {
         "@babel/runtime-corejs3": "^7.21.5",
         "@braintree/sanitize-url": "=6.0.2",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "reselect": "^4.1.7",
     "short-unique-id": "^4.4.4",
     "styled-components": "^5.3.10",
-    "swagger-ui-react": "^5.0.0-alpha.10",
+    "swagger-ui-react": "^5.0.0-alpha.12",
     "vscode": "npm:@codingame/monaco-vscode-api@~1.76.7",
     "vscode-languageclient": "^8.1.0",
     "vscode-languageserver-textdocument": "^1.0.8"


### PR DESCRIPTION
Supported vocabularies:
 - Core vocabulary
 - Validation vocabulary
 - OpenAPI 3.1.0 base vocabulary

Refs https://github.com/swagger-api/swagger-ui/releases/tag/v5.0.0-alpha.12

