### PR TITLE
fix(monaco-language-apidom): register diagnostics provider early

### DIFF
--- a/src/plugins/editor-monaco-language-apidom/language/apidom-mode.js
+++ b/src/plugins/editor-monaco-language-apidom/language/apidom-mode.js
@@ -38,10 +38,15 @@ const registerProviders = ({ languageId, providers, dependencies }) => {
   const { worker, codeConverter, protocolConverter } = dependencies;
   const args = [worker, codeConverter, protocolConverter];
 
+  /**
+   * Customized providers needs to be registered before monaco editor is created
+   * and services are initialized.
+   */
+  providers.push(new DiagnosticsProvider(...args));
+
   (async () => {
     await initializeExtensions();
 
-    providers.push(new DiagnosticsProvider(...args));
     providers.push(vscodeLanguages.registerHoverProvider(languageId, new HoverProvider(...args)));
     providers.push(
       vscodeLanguages.registerDocumentLinkProvider(languageId, new DocumentLinkProvider(...args))


### PR DESCRIPTION
Customized providers (like the diagnostics provider) needs to be registered before monaco editor is created
and services are initialized.