### PR TITLE
fix(monaco-language-apidom): completion filtering

### DIFF
--- a/src/plugins/editor-monaco-language-apidom/language/providers/CompletionItemProvider.js
+++ b/src/plugins/editor-monaco-language-apidom/language/providers/CompletionItemProvider.js
@@ -21,8 +21,25 @@ class CompletionItemProvider extends Provider {
 
   async provideCompletionItems(vscodeDocument, position) {
     const completionList = await this.#getCompletionList(vscodeDocument, position);
+    const range = vscodeDocument.getWordRangeAtPosition(position, /[a-zA-Z.]+/);
+    const text = vscodeDocument.getText(range);
+    const { items } = completionList;
 
-    return this.protocolConverter.asCompletionResult(completionList);
+    const isSubsequence = (label) => {
+      const counter = label.split('').reduce((acc, el) => {
+        if (text[acc]?.toLowerCase() === el?.toLowerCase()) {
+          const increment = acc + 1;
+          return increment;
+        }
+        return acc;
+      }, 0);
+
+      return counter === text.length;
+    };
+
+    return this.protocolConverter.asCompletionResult(
+      items.filter(({ label }) => isSubsequence(label))
+    );
   }
 }
 


### PR DESCRIPTION
Refs #4216

The implementation filters out completion items which have labels that don't contain the input as a subsequence.