### PR TITLE
docs(monaco-language-apidom): document completion filter option

### DIFF
--- a/src/plugins/editor-monaco-language-apidom/language/ApiDOMWorker.js
+++ b/src/plugins/editor-monaco-language-apidom/language/ApiDOMWorker.js
@@ -13,6 +13,9 @@ export class ApiDOMWorker {
     },
     completionContext: {
       maxNumberOfItems: 100,
+      // ENABLE to have "strict" word filtering (instead of default Monaco fuzzy matching)
+      // see https://github.com/swagger-api/apidom/pull/2954
+      // enableLSPFilter: true,
     },
   };
 


### PR DESCRIPTION
Refs #4216

add comment/placeholder to enable language service "strict" completion filter. See #4216