### PR TITLE
fix(editor-preview): reset error boundaries on editor content change

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,25 +24,8 @@ import EditorContentOriginPlugin from './plugins/editor-content-origin/index.js'
 import EditorContentTypePlugin from './plugins/editor-content-type/index.js';
 import EditorContentPersistencePlugin from './plugins/editor-content-persistence/index.js';
 import EditorContentFixturesPlugin from './plugins/editor-content-fixtures/index.js';
+import EditorSafeRenderPlugin from './plugins/editor-safe-render/index.js';
 import SwaggerUIAdapterPlugin from './plugins/swagger-ui-adapter/index.js';
-
-const SafeRenderPlugin = (system) =>
-  SwaggerUI.plugins.SafeRender({
-    componentList: [
-      'TopBar',
-      'SwaggerEditorLayout',
-      'Editor',
-      'EditorTextarea',
-      'EditorMonaco',
-      'EditorPane',
-      'EditorPaneBarTop',
-      'EditorPreviewPane',
-      'ValidationPane',
-      'AlertDialog',
-      'ConfirmDialog',
-      'Dropzone',
-    ],
-  })(system);
 
 const SwaggerEditor = React.memo((props) => {
   const mergedProps = deepmerge(SwaggerEditor.defaultProps, props);
@@ -73,6 +56,7 @@ SwaggerEditor.plugins = {
   EditorPreviewSwaggerUI: EditorPreviewSwaggerUIPlugin,
   EditorPreviewAsyncAPI: EditorPreviewAsyncAPIPlugin,
   EditorPreviewApiDesignSystems: EditorPreviewApiDesignSystemsPlugin,
+  EditorSafeRender: EditorSafeRenderPlugin,
   TopBar: TopBarPlugin,
   SplashScreenPlugin,
   Layout: LayoutPlugin,
@@ -98,7 +82,7 @@ SwaggerEditor.presets = {
     TopBarPlugin,
     SplashScreenPlugin,
     LayoutPlugin,
-    SafeRenderPlugin,
+    EditorSafeRenderPlugin,
   ],
   monaco: () => [
     ModalsPlugin,
@@ -121,7 +105,7 @@ SwaggerEditor.presets = {
     TopBarPlugin,
     SplashScreenPlugin,
     LayoutPlugin,
-    SafeRenderPlugin,
+    EditorSafeRenderPlugin,
   ],
   default: (...args) => SwaggerEditor.presets.monaco(...args),
 };

--- a/src/plugins/editor-safe-render/components/ErrorBoundary.jsx
+++ b/src/plugins/editor-safe-render/components/ErrorBoundary.jsx
@@ -1,0 +1,74 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+
+class ErrorBoundary extends Component {
+  static defaultState = { hasError: false, error: null, editorContent: null };
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  constructor(...args) {
+    super(...args);
+    this.state = this.constructor.defaultState;
+  }
+
+  componentDidMount() {
+    const { editorSelectors } = this.props;
+
+    this.setState({ editorContent: editorSelectors.selectContent() });
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    const { editorSelectors } = this.props;
+    const hasEditorContentChanged = prevState.editorContent !== editorSelectors.selectContent();
+
+    if (!hasEditorContentChanged) return;
+
+    const newState = { editorContent: editorSelectors.selectContent() };
+
+    if (prevState.hasError) {
+      newState.hasError = false;
+      newState.error = null;
+    }
+
+    this.setState(newState);
+  }
+
+  componentDidCatch(error, errorInfo) {
+    const {
+      fn: { componentDidCatch },
+    } = this.props;
+
+    componentDidCatch(error, errorInfo);
+  }
+
+  render() {
+    const { hasError, error } = this.state;
+    const { getComponent, targetName, children } = this.props;
+
+    if (hasError && error) {
+      const FallbackComponent = getComponent('Fallback');
+      return <FallbackComponent name={targetName} />;
+    }
+
+    return children;
+  }
+}
+ErrorBoundary.propTypes = {
+  targetName: PropTypes.string,
+  getComponent: PropTypes.func.isRequired,
+  fn: PropTypes.shape({
+    componentDidCatch: PropTypes.func.isRequired,
+  }).isRequired,
+  editorSelectors: PropTypes.shape({
+    selectContent: PropTypes.func.isRequired,
+  }).isRequired,
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
+};
+ErrorBoundary.defaultProps = {
+  targetName: 'this component',
+  children: null,
+};
+
+export default ErrorBoundary;

--- a/src/plugins/editor-safe-render/index.js
+++ b/src/plugins/editor-safe-render/index.js
@@ -1,0 +1,39 @@
+import SwaggerUI from 'swagger-ui-react';
+
+import ErrorBoundaryWrapper from './wrap-components/ErrorBoundaryWrapper.jsx';
+
+/**
+ * This is special version of SwaggerUI.plugins.SafeRender.
+ * In editor context, we want to dismiss the error produced
+ * in error boundary if editor content has changed.
+ */
+const EditorSafeRenderPlugin = () => {
+  const safeRenderPlugin = () =>
+    SwaggerUI.plugins.SafeRender({
+      fullOverride: true,
+      componentList: [
+        'TopBar',
+        'SwaggerEditorLayout',
+        'Editor',
+        'EditorTextarea',
+        'EditorMonaco',
+        'EditorPane',
+        'EditorPaneBarTop',
+        'EditorPreviewPane',
+        'ValidationPane',
+        'AlertDialog',
+        'ConfirmDialog',
+        'Dropzone',
+      ],
+    });
+
+  const safeRenderPluginOverride = () => ({
+    wrapComponents: {
+      ErrorBoundary: ErrorBoundaryWrapper,
+    },
+  });
+
+  return [safeRenderPlugin, safeRenderPluginOverride];
+};
+
+export default EditorSafeRenderPlugin;

--- a/src/plugins/editor-safe-render/wrap-components/ErrorBoundaryWrapper.jsx
+++ b/src/plugins/editor-safe-render/wrap-components/ErrorBoundaryWrapper.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import ErrorBoundary from '../components/ErrorBoundary.jsx';
+
+const ErrorBoundaryWrapper = (Original, system) => {
+  const ErrorBoundaryOverride = (props) => {
+    const { editorSelectors } = system;
+
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    return <ErrorBoundary {...props} editorSelectors={editorSelectors} />;
+  };
+
+  return ErrorBoundaryOverride;
+};
+
+export default ErrorBoundaryWrapper;


### PR DESCRIPTION
When following AsyncAPI definition was provided to the editor, the AsyncAPI renderer crashed, error boundary caught the error and displayed the fallback component. When we changed the editor content to fix the issue, the fallback component was still displaying, because it's error state was persistent. This is fine in SwaggerUI content, where the definition is immutable. But it's impractical in SwaggerEditor@5 content, where definition always changes. This PR introduces override for error boundary mechanism provided by SwaggerUI, which detects if editor has changed. If the editor content has changed the error boundary state resets.

**Definition**:
```yaml
asyncapi: '2.6.0'
info:
  title: AsyncAPI
  version: '1.0.0'
channels:
  'foo':
    description: Bar.
    publish:
      message:
        oneOf:
          - $ref: '#/components/messages/Foo'
       
          
components:
  messages:
    Foo:
      name: Foo
      payload:
        $ref: "#/components/schemas/Bar"
      examples:
        - name: standard
          payload:
            after: 
              oneOf:
              - $ref: '#/components/messages/Foo'
              
  schemas:
    Bar:
      type: object
      properties:
        eventType:
          type: string
          desciption: Foo
```

**Fallback component displayed instead of rendered AsyncAPI definition:**

![image](https://github.com/swagger-api/swagger-editor/assets/193286/998b805d-5afe-4891-9bb0-cc5a115b860d)
