### PR TITLE
feat: extract presets to reusable modules

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,9 @@ import SwaggerUI from 'swagger-ui-react';
 import 'swagger-ui-react/swagger-ui.css';
 
 import './styles/main.scss';
+/**
+ * Plugins
+ */
 import LayoutPlugin from './plugins/layout/index.js';
 import SplashScreenPlugin from './plugins/splash-screen/index.js';
 import TopBarPlugin from './plugins/top-bar/index.js';
@@ -26,6 +29,11 @@ import EditorContentPersistencePlugin from './plugins/editor-content-persistence
 import EditorContentFixturesPlugin from './plugins/editor-content-fixtures/index.js';
 import EditorSafeRenderPlugin from './plugins/editor-safe-render/index.js';
 import SwaggerUIAdapterPlugin from './plugins/swagger-ui-adapter/index.js';
+/**
+ * Presets
+ */
+import TextareaPreset from './presets/textarea/index.js';
+import MonacoPreset from './presets/monaco/index.js';
 
 const SwaggerEditor = React.memo((props) => {
   const mergedProps = deepmerge(SwaggerEditor.defaultProps, props);
@@ -63,51 +71,9 @@ SwaggerEditor.plugins = {
   SwaggerUIAdapter: SwaggerUIAdapterPlugin,
 };
 SwaggerEditor.presets = {
-  textarea: () => [
-    ModalsPlugin,
-    DialogsPlugin,
-    DropdownMenuPlugin,
-    DropzonePlugin,
-    VersionsPlugin,
-    EditorTextareaPlugin,
-    EditorContentReadOnlyPlugin,
-    EditorContentOriginPlugin,
-    EditorContentTypePlugin,
-    EditorContentPersistencePlugin,
-    EditorContentFixturesPlugin,
-    EditorPreviewPlugin,
-    EditorPreviewSwaggerUIPlugin,
-    EditorPreviewAsyncAPIPlugin,
-    EditorPreviewApiDesignSystemsPlugin,
-    TopBarPlugin,
-    SplashScreenPlugin,
-    LayoutPlugin,
-    EditorSafeRenderPlugin,
-  ],
-  monaco: () => [
-    ModalsPlugin,
-    DialogsPlugin,
-    DropdownMenuPlugin,
-    DropzonePlugin,
-    VersionsPlugin,
-    EditorTextareaPlugin,
-    EditorMonacoPlugin,
-    EditorMonacoLanguageApiDOMPlugin,
-    EditorContentReadOnlyPlugin,
-    EditorContentOriginPlugin,
-    EditorContentTypePlugin,
-    EditorContentPersistencePlugin,
-    EditorContentFixturesPlugin,
-    EditorPreviewPlugin,
-    EditorPreviewSwaggerUIPlugin,
-    EditorPreviewAsyncAPIPlugin,
-    EditorPreviewApiDesignSystemsPlugin,
-    TopBarPlugin,
-    SplashScreenPlugin,
-    LayoutPlugin,
-    EditorSafeRenderPlugin,
-  ],
-  default: (...args) => SwaggerEditor.presets.monaco(...args),
+  textarea: TextareaPreset,
+  monaco: MonacoPreset,
+  default: MonacoPreset,
 };
 
 SwaggerEditor.propTypes = SwaggerUI.propTypes;

--- a/src/presets/monaco/index.js
+++ b/src/presets/monaco/index.js
@@ -1,0 +1,47 @@
+import ModalsPlugin from '../../plugins/modals/index.js';
+import DialogsPlugin from '../../plugins/dialogs/index.js';
+import DropdownMenuPlugin from '../../plugins/dropdown-menu/index.js';
+import DropzonePlugin from '../../plugins/dropzone/index.js';
+import VersionsPlugin from '../../plugins/versions/index.js';
+import EditorTextareaPlugin from '../../plugins/editor-textarea/index.js';
+import EditorMonacoPlugin from '../../plugins/editor-monaco/index.js';
+import EditorMonacoLanguageApiDOMPlugin from '../../plugins/editor-monaco-language-apidom/index.js';
+import EditorContentReadOnlyPlugin from '../../plugins/editor-content-read-only/index.js';
+import EditorContentOriginPlugin from '../../plugins/editor-content-origin/index.js';
+import EditorContentTypePlugin from '../../plugins/editor-content-type/index.js';
+import EditorContentPersistencePlugin from '../../plugins/editor-content-persistence/index.js';
+import EditorContentFixturesPlugin from '../../plugins/editor-content-fixtures/index.js';
+import EditorPreviewPlugin from '../../plugins/editor-preview/index.js';
+import EditorPreviewSwaggerUIPlugin from '../../plugins/editor-preview-swagger-ui/index.js';
+import EditorPreviewAsyncAPIPlugin from '../../plugins/editor-preview-asyncapi/index.js';
+import EditorPreviewApiDesignSystemsPlugin from '../../plugins/editor-preview-api-design-systems/index.js';
+import TopBarPlugin from '../../plugins/top-bar/index.js';
+import SplashScreenPlugin from '../../plugins/splash-screen/index.js';
+import LayoutPlugin from '../../plugins/layout/index.js';
+import EditorSafeRenderPlugin from '../../plugins/editor-safe-render/index.js';
+
+const MonacoPreset = () => [
+  ModalsPlugin,
+  DialogsPlugin,
+  DropdownMenuPlugin,
+  DropzonePlugin,
+  VersionsPlugin,
+  EditorTextareaPlugin,
+  EditorMonacoPlugin,
+  EditorMonacoLanguageApiDOMPlugin,
+  EditorContentReadOnlyPlugin,
+  EditorContentOriginPlugin,
+  EditorContentTypePlugin,
+  EditorContentPersistencePlugin,
+  EditorContentFixturesPlugin,
+  EditorPreviewPlugin,
+  EditorPreviewSwaggerUIPlugin,
+  EditorPreviewAsyncAPIPlugin,
+  EditorPreviewApiDesignSystemsPlugin,
+  TopBarPlugin,
+  SplashScreenPlugin,
+  LayoutPlugin,
+  EditorSafeRenderPlugin,
+];
+
+export default MonacoPreset;

--- a/src/presets/textarea/index.js
+++ b/src/presets/textarea/index.js
@@ -1,0 +1,43 @@
+import LayoutPlugin from '../../plugins/layout/index.js';
+import SplashScreenPlugin from '../../plugins/splash-screen/index.js';
+import TopBarPlugin from '../../plugins/top-bar/index.js';
+import ModalsPlugin from '../../plugins/modals/index.js';
+import DialogsPlugin from '../../plugins/dialogs/index.js';
+import DropdownMenuPlugin from '../../plugins/dropdown-menu/index.js';
+import DropzonePlugin from '../../plugins/dropzone/index.js';
+import VersionsPlugin from '../../plugins/versions/index.js';
+import EditorTextareaPlugin from '../../plugins/editor-textarea/index.js';
+import EditorPreviewPlugin from '../../plugins/editor-preview/index.js';
+import EditorPreviewSwaggerUIPlugin from '../../plugins/editor-preview-swagger-ui/index.js';
+import EditorPreviewAsyncAPIPlugin from '../../plugins/editor-preview-asyncapi/index.js';
+import EditorPreviewApiDesignSystemsPlugin from '../../plugins/editor-preview-api-design-systems/index.js';
+import EditorContentReadOnlyPlugin from '../../plugins/editor-content-read-only/index.js';
+import EditorContentOriginPlugin from '../../plugins/editor-content-origin/index.js';
+import EditorContentTypePlugin from '../../plugins/editor-content-type/index.js';
+import EditorContentPersistencePlugin from '../../plugins/editor-content-persistence/index.js';
+import EditorContentFixturesPlugin from '../../plugins/editor-content-fixtures/index.js';
+import EditorSafeRenderPlugin from '../../plugins/editor-safe-render/index.js';
+
+const TextareaPreset = () => [
+  ModalsPlugin,
+  DialogsPlugin,
+  DropdownMenuPlugin,
+  DropzonePlugin,
+  VersionsPlugin,
+  EditorTextareaPlugin,
+  EditorContentReadOnlyPlugin,
+  EditorContentOriginPlugin,
+  EditorContentTypePlugin,
+  EditorContentPersistencePlugin,
+  EditorContentFixturesPlugin,
+  EditorPreviewPlugin,
+  EditorPreviewSwaggerUIPlugin,
+  EditorPreviewAsyncAPIPlugin,
+  EditorPreviewApiDesignSystemsPlugin,
+  TopBarPlugin,
+  SplashScreenPlugin,
+  LayoutPlugin,
+  EditorSafeRenderPlugin,
+];
+
+export default TextareaPreset;


### PR DESCRIPTION
This will help in exposing the `presets` via package.json `exports` field in future.