### PR TITLE
fix(monaco-editor): pin monaco-editor + VSCode combo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "js-file-download": "^0.4.12",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
-        "monaco-editor": "^0.44.0",
+        "monaco-editor": "=0.44.0",
         "monaco-marker-data-provider": "^1.1.1",
         "prop-types": "^15.8.1",
         "react": "^17.0.2",
@@ -58,7 +58,7 @@
         "short-unique-id": "^4.4.4",
         "styled-components": "^6.1.1",
         "swagger-ui-react": "^5.10.0",
-        "vscode": "npm:@codingame/monaco-vscode-api@~1.83.5",
+        "vscode": "npm:@codingame/monaco-vscode-api@=1.83.5",
         "vscode-languageclient": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.11"
       },

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
   "dependencies": {
     "@asyncapi/avro-schema-parser": "^1.1.0",
     "@asyncapi/openapi-schema-parser": "^2.0.3",
-    "@asyncapi/protobuf-schema-parser": "^1.0.0",
     "@asyncapi/parser": "^1.18.1",
+    "@asyncapi/protobuf-schema-parser": "^1.0.0",
     "@asyncapi/react-component": "=1.2.2",
     "@babel/runtime": "^7.23.2",
     "@braintree/sanitize-url": "^6.0.3",
@@ -90,7 +90,7 @@
     "js-file-download": "^0.4.12",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
-    "monaco-editor": "^0.44.0",
+    "monaco-editor": "=0.44.0",
     "monaco-marker-data-provider": "^1.1.1",
     "prop-types": "^15.8.1",
     "react": "^17.0.2",
@@ -104,7 +104,7 @@
     "short-unique-id": "^4.4.4",
     "styled-components": "^6.1.1",
     "swagger-ui-react": "^5.10.0",
-    "vscode": "npm:@codingame/monaco-vscode-api@~1.83.5",
+    "vscode": "npm:@codingame/monaco-vscode-api@=1.83.5",
     "vscode-languageclient": "^9.0.1",
     "vscode-languageserver-textdocument": "^1.0.11"
   },


### PR DESCRIPTION
Without pinning, the VSCode API can introduce
breaking changes in patch releases.

