### PR TITLE
fix(editor-monaco): display commands palette dialog

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -49,6 +49,7 @@
         "^monaco-languageclient\/monaco-converter$",
         "^vscode\/services$",
         "^vscode\/extensions$",
+        "^vscode\/vscode",
         "^vscode\/service-override",
         "^plugins\/.+\/index.js",
         "^presets\/.+\/index.js"

--- a/src/plugins/editor-monaco/monaco-contribution/index.js
+++ b/src/plugins/editor-monaco/monaco-contribution/index.js
@@ -1,5 +1,12 @@
 import * as monaco from 'monaco-editor';
 import { StandaloneServices, IStorageService } from 'vscode/services';
+/**
+ * This is quick fix for displaying command palette.
+ *
+ * {@link https://github.com/CodinGame/monaco-vscode-api/issues/267}
+ * @TODO(vladimir.gorej@gmail.com): this can be removed with next VSCode API release.
+ */
+import 'vscode/vscode/vs/workbench/browser/workbench.contribution';
 
 import goToSymbolActionDescriptor from './actions/go-to-symbol.js';
 


### PR DESCRIPTION
Refs https://github.com/CodinGame/monaco-vscode-api/issues/267
