### PR TITLE
fix(editor-monaco): remove workaroud code for services initialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "short-unique-id": "^4.4.4",
         "styled-components": "^6.1.1",
         "swagger-ui-react": "^5.10.3",
-        "vscode": "npm:@codingame/monaco-vscode-api@=1.83.15",
+        "vscode": "npm:@codingame/monaco-vscode-api@=1.83.16",
         "vscode-languageclient": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.11"
       },
@@ -2839,50 +2839,50 @@
       "integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A=="
     },
     "node_modules/@codingame/monaco-vscode-environment-service-override": {
-      "version": "1.83.15",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-1.83.15.tgz",
-      "integrity": "sha512-MIlInjTF1Ehf4N4RS+bFe3tZhWUHtrKgDRs9fk3NOO1K3dAUx+a1+JlnhQutFOqudmUM1WEE9jk5GrFoVYmSVQ==",
+      "version": "1.83.16",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-1.83.16.tgz",
+      "integrity": "sha512-W/60KsaHwWNEI6Dl9lld5CCYyQvoQjXpqPU3XT7CT2VKaeilL20M7sj0MLA8tJWAbFoNt0DrcvTyNC1CCD85/Q==",
       "dependencies": {
         "monaco-editor": "0.44.0",
-        "vscode": "npm:@codingame/monaco-vscode-api@1.83.15"
+        "vscode": "npm:@codingame/monaco-vscode-api@1.83.16"
       }
     },
     "node_modules/@codingame/monaco-vscode-extensions-service-override": {
-      "version": "1.83.15",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-1.83.15.tgz",
-      "integrity": "sha512-zAjW8Mj/18G5N3L6Vi9He9zFrJcGaj7fbX/7UoXea8bq4yYhhc9DLJcPpm0s9iGffnLp9JjhxnlgKOBw4aZOeA==",
+      "version": "1.83.16",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-1.83.16.tgz",
+      "integrity": "sha512-zltPGafTUt/V1PRyGGuLlOMthF5vthBb8dPuu4+E/qlB31jc3ygj+DIFMbpqhtzXywBZeUyAn/aiXO4/b/sHFQ==",
       "dependencies": {
-        "@codingame/monaco-vscode-files-service-override": "1.83.15",
+        "@codingame/monaco-vscode-files-service-override": "1.83.16",
         "monaco-editor": "0.44.0",
-        "vscode": "npm:@codingame/monaco-vscode-api@1.83.15",
+        "vscode": "npm:@codingame/monaco-vscode-api@1.83.16",
         "vscode-semver": "npm:semver@=5.5.0"
       }
     },
     "node_modules/@codingame/monaco-vscode-files-service-override": {
-      "version": "1.83.15",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-1.83.15.tgz",
-      "integrity": "sha512-PxxLY3pczbdZy62jdcVvdNmpYTsxtwEwZanprerohTzw2MTryk8HHKRpcYSlQP+j8bxnKrXVAK03W+D3t7DeBg==",
+      "version": "1.83.16",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-1.83.16.tgz",
+      "integrity": "sha512-agyigI7n6KzjWEgAZJKncuwQldpbjN19Bmr30LFp2ENh/1ezNPYP/SvhkTyQQTL/YDsup3FkkX2NH54fzOia9w==",
       "dependencies": {
         "monaco-editor": "0.44.0",
-        "vscode": "npm:@codingame/monaco-vscode-api@1.83.15"
+        "vscode": "npm:@codingame/monaco-vscode-api@1.83.16"
       }
     },
     "node_modules/@codingame/monaco-vscode-layout-service-override": {
-      "version": "1.83.15",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-1.83.15.tgz",
-      "integrity": "sha512-bN09fkVitQYSyjfPwOoeTA9WsRM3SSERuE+YrTtJhOAs60urN2h5fVSADg/9EEa8yEHk43PTmOs6Y8k+UG/efQ==",
+      "version": "1.83.16",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-1.83.16.tgz",
+      "integrity": "sha512-DOHpZVqLP8RVDwQYPP3hDd+LPjxSyBbgPL3Ixd1X9LZSmY37bi95ILOPESqG306h2wQZhPzwNC+E7UNY3P/Ing==",
       "dependencies": {
         "monaco-editor": "0.44.0",
-        "vscode": "npm:@codingame/monaco-vscode-api@1.83.15"
+        "vscode": "npm:@codingame/monaco-vscode-api@1.83.16"
       }
     },
     "node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
-      "version": "1.83.15",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-1.83.15.tgz",
-      "integrity": "sha512-2hP5tiDBah8YoMkNRkbaUQT5Cf3lm7MVy6LDYDh5sgfVPtr24N4kx7nSob5osW2ZzOnPS0agxMoWKIbHKu/kVw==",
+      "version": "1.83.16",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-1.83.16.tgz",
+      "integrity": "sha512-uO1xJKkoI7wvyOT+WvopA3Sehy9yLk5bUi+QAESZbXLhvVMutbl2mO1T0stgC7O3cPOJnNh9xIi/kexW2TswOQ==",
       "dependencies": {
         "monaco-editor": "0.44.0",
-        "vscode": "npm:@codingame/monaco-vscode-api@1.83.15"
+        "vscode": "npm:@codingame/monaco-vscode-api@1.83.16"
       }
     },
     "node_modules/@colors/colors": {
@@ -28081,15 +28081,15 @@
     },
     "node_modules/vscode": {
       "name": "@codingame/monaco-vscode-api",
-      "version": "1.83.15",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-1.83.15.tgz",
-      "integrity": "sha512-/f8TeUvnmNKm+ZsHwjwzv4dqvSnTFaKgN0ZBE2m/exAh4TMFTCttiFnXjkSimoyffyZtP/kTE0RODzScreD2zQ==",
+      "version": "1.83.16",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-1.83.16.tgz",
+      "integrity": "sha512-8+jBcXKkvqfx5mVfaUQ+TeORIw2zGRASoKCavZCO/BSpnTCrPVTFyT2HN35+Hwun8eGqoWaNaKYunupLiBZRWg==",
       "dependencies": {
-        "@codingame/monaco-vscode-environment-service-override": "1.83.15",
-        "@codingame/monaco-vscode-extensions-service-override": "1.83.15",
-        "@codingame/monaco-vscode-files-service-override": "1.83.15",
-        "@codingame/monaco-vscode-layout-service-override": "1.83.15",
-        "@codingame/monaco-vscode-quickaccess-service-override": "1.83.15",
+        "@codingame/monaco-vscode-environment-service-override": "1.83.16",
+        "@codingame/monaco-vscode-extensions-service-override": "1.83.16",
+        "@codingame/monaco-vscode-files-service-override": "1.83.16",
+        "@codingame/monaco-vscode-layout-service-override": "1.83.16",
+        "@codingame/monaco-vscode-quickaccess-service-override": "1.83.16",
         "monaco-editor": "0.44.0",
         "vscode-semver": "npm:semver@=5.5.0"
       },

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "short-unique-id": "^4.4.4",
     "styled-components": "^6.1.1",
     "swagger-ui-react": "^5.10.3",
-    "vscode": "npm:@codingame/monaco-vscode-api@=1.83.15",
+    "vscode": "npm:@codingame/monaco-vscode-api@=1.83.16",
     "vscode-languageclient": "^9.0.1",
     "vscode-languageserver-textdocument": "^1.0.11"
   },

--- a/src/plugins/editor-monaco/after-load.js
+++ b/src/plugins/editor-monaco/after-load.js
@@ -1,6 +1,4 @@
 import { initialize as initializeMonacoServices } from 'vscode/services';
-import { IExtensionService } from 'vscode/vscode/vs/workbench/services/extensions/common/extensions';
-import { registerServiceInitializeParticipant } from 'vscode/lifecycle';
 import 'vscode/localExtensionHost';
 
 import lazyMonacoContribution from './monaco-contribution/index.js';
@@ -35,11 +33,6 @@ function afterLoad(system) {
 
     (async () => {
       try {
-        /**
-         * {@link https://github.com/CodinGame/monaco-vscode-api/issues/283}
-         * @TODO(vladimir.gorej@gmail.com): this can go away with next release of vscode >1.83.15
-         */
-        registerServiceInitializeParticipant((accessor) => accessor.get(IExtensionService));
         await initializeMonacoServices({});
         system.monacoInitializationDeferred().resolve();
       } catch (error) {


### PR DESCRIPTION
The upstream vscode@1.83.16 now contains the fix.

