### PR TITLE
feat: add oauth2 redirect route

### DIFF
--- a/public/oauth2-redirect.html
+++ b/public/oauth2-redirect.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en-US">
+<title>Swagger UI: OAuth2 Redirect</title>
+
+<body onload="run()">
+</body>
+
+</html>
+<script>
+    'use strict';
+    function run() {
+        var oauth2 = window.opener.swaggerUIRedirectOauth2;
+        var sentState = oauth2.state;
+        var redirectUrl = oauth2.redirectUrl;
+        var isValid, qp, arr;
+
+        if (/code|token|error/.test(window.location.hash)) {
+            qp = window.location.hash.substring(1);
+        } else {
+            qp = location.search.substring(1);
+        }
+
+        arr = qp.split("&")
+        arr.forEach(function (v, i, _arr) { _arr[i] = '"' + v.replace('=', '":"') + '"'; })
+        qp = qp ? JSON.parse('{' + arr.join() + '}',
+            function (key, value) {
+                return key === "" ? value : decodeURIComponent(value)
+            }
+        ) : {}
+
+        isValid = qp.state === sentState
+
+        console.log(oauth2.auth)
+        if ((
+            oauth2.auth.schema.get("flow") === "accessCode" ||
+            oauth2.auth.schema.get("flow") === "authorizationCode" ||
+            oauth2.auth.schema.get("flow") === "access_code" ||
+            oauth2.auth.schema.get("flow") === "authorization_code"
+        ) && !oauth2.auth.code) {
+            if (!isValid) {
+                oauth2.errCb({
+                    authId: oauth2.auth.name,
+                    source: "auth",
+                    level: "warning",
+                    message: "Authorization may be unsafe, passed state was changed in server Passed state wasn't returned from auth server"
+                });
+            }
+
+            if (qp.code) {
+                delete oauth2.state;
+                oauth2.auth.code = qp.code;
+                oauth2.callback({ auth: oauth2.auth, redirectUrl: redirectUrl });
+            } else {
+                let oauthErrorMsg
+                if (qp.error) {
+                    oauthErrorMsg = "[" + qp.error + "]: " +
+                        (qp.error_description ? qp.error_description + ". " : "no accessCode received from the server. ") +
+                        (qp.error_uri ? "More info: " + qp.error_uri : "");
+                }
+
+                oauth2.errCb({
+                    authId: oauth2.auth.name,
+                    source: "auth",
+                    level: "error",
+                    message: oauthErrorMsg || "[Authorization failed]: no accessCode received from the server"
+                });
+            }
+        } else {
+            oauth2.callback({ auth: oauth2.auth, token: qp, isValid: isValid, redirectUrl: redirectUrl });
+        }
+        window.close();
+    }
+</script>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Add oauth2 redirect handler route. The oauth2-redirect.html file is copied from `master` branch, with a little addition that accepts both snake case and camel cases oauth2 from oauth2 server.

With this commit, swagger editor `next` can finally work with openId/oauth2 authorization_code workflow.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

The swagger editor just don't handle oauth2/openIdConnect callback when using authorization_code workflow. It just complains a 404 not found.
<img width="1044" alt="image" src="https://github.com/swagger-api/swagger-editor/assets/16273287/b8195598-ba2c-4641-a8f3-5ad706cb851f">
The same configuration works in the `https://editor.swagger.io/`, which follows the `master` branch.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have tested in local development `npm run start` and `npm run build`. I think it can works in docker too.

### Screenshots (if appropriate):
<img width="658" alt="image" src="https://github.com/swagger-api/swagger-editor/assets/16273287/21038771-aea2-4d34-be08-253c50c14c81">



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
