### PR TITLE
test(cypress): make cypress tests run smoothly

### DIFF
--- a/test/cypress/e2e/plugin.editor-persistence.cy.js
+++ b/test/cypress/e2e/plugin.editor-persistence.cy.js
@@ -13,7 +13,7 @@ describe('EditorPersistencePlugin', () => {
       .should('contains.text', '2.6.0');
   });
 
-  it.skip('should reload while keeping text change from 2.6.0 to 2.5.0', () => {
+  it('should reload while keeping text change from 2.6.0 to 2.5.0', () => {
     cy.prepareAsyncAPI();
     cy.waitForSplashScreen();
 

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -27,21 +27,6 @@
 import '@testing-library/cypress/add-commands.js';
 import 'cypress-file-upload';
 
-Cypress.on('window:before:load', (win) => {
-  cy.stub(win.console, 'error', (msg) => {
-    cy.now('task', 'error', msg);
-  });
-
-  cy.stub(win.console, 'warn', (msg) => {
-    cy.now('task', 'warn', msg);
-  });
-});
-
-Cypress.on('uncaught:exception', (err) => {
-  cy.now('task', 'uncaught', err);
-  return true; // true = fail the test
-});
-
 Cypress.Commands.add('prepareAsyncAPI', () => {
   cy.intercept(
     'GET',


### PR DESCRIPTION
I've removed the code that case either causing issues when running tests or code that just did nothing.

Code that was causing the crashes was:

```js
  cy.stub(win.console, 'warn', (msg) => {
    cy.now('task', 'warn', msg);
  });
```