### PR TITLE
feat(analytics): use Scarf.js to provide anonymized installation analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,23 @@ This repository publishes to two different NPM modules:
 
 If you're building a single-page application, using `swagger-editor` is strongly recommended, since `swagger-editor-dist` is significantly larger.
 
+## Anonymized analytics
+
+Swagger Editor uses [Scarf](https://scarf.sh/) to collect [anonymized installation analytics](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-what-information-does-scarf-js-send-about-me). These analytics help support the maintainers of this library and ONLY run during installation. To [opt out](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-how-can-i-opt-out-of-analytics), you can set the `scarfSettings.enabled` field to `false` in your project's `package.json`:
+
+```
+// package.json
+{
+  // ...
+  "scarfSettings": {
+    "enabled": false
+  }
+  // ...
+}
+```
+
+Alternatively, you can set the environment variable `SCARF_ANALYTICS` to `false` as part of the environment that installs your npm packages, e.g., `SCARF_ANALYTICS=false npm install`.
+
 ## Helpful scripts
 
 Any of the scripts below can be run by typing `npm run <script name>` in the project's root directory.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@scarf/scarf": "=1.3.0",
         "ajv": "^6.12.3",
         "ajv-errors": "^1.0.1",
         "ajv-keywords": "^3.5.2",
@@ -29636,20 +29637,6 @@
       "integrity": "sha512-1HTsf5/QVRmLzcGfldPFvkVsAdi1db1BBKzi7iW3KBUlOICg/nKnFS+jGqDJS3YD8VsWbAh7JiHeBvbsw8RPxA==",
       "dependencies": {
         "ts-toolbelt": "^9.6.0"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/typical": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "watch": "webpack --config  webpack/core.babel.js --watch --progress"
   },
   "dependencies": {
+    "@scarf/scarf": "=1.3.0",
     "ajv": "^6.12.3",
     "ajv-errors": "^1.0.1",
     "ajv-keywords": "^3.5.2",

--- a/swagger-editor-dist-package/README.md
+++ b/swagger-editor-dist-package/README.md
@@ -1,6 +1,6 @@
 # swagger-editor-dist
 
-This module, `swagger-editor-dist`, exposes Swagger-Editor's entire dist folder as a dependency-free npm module.
+This module, `swagger-editor-dist`, exposes Swagger-Editor's entire dist folder as an almost (see [anonymized analytics](#anonymized-analytics)) dependency-free npm module.
 
 Use `swagger-editor` instead, if you'd like to have npm install dependencies for you.
 

--- a/swagger-editor-dist-package/README.md
+++ b/swagger-editor-dist-package/README.md
@@ -1,3 +1,22 @@
+# swagger-editor-dist
+
 This module, `swagger-editor-dist`, exposes Swagger-Editor's entire dist folder as a dependency-free npm module.
 
 Use `swagger-editor` instead, if you'd like to have npm install dependencies for you.
+
+## Anonymized analytics
+
+`swagger-editor-dist` uses [Scarf](https://scarf.sh/) to collect [anonymized installation analytics](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-what-information-does-scarf-js-send-about-me). These analytics help support the maintainers of this library and ONLY run during installation. To [opt out](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-how-can-i-opt-out-of-analytics), you can set the `scarfSettings.enabled` field to `false` in your project's `package.json`:
+
+```
+// package.json
+{
+  // ...
+  "scarfSettings": {
+    "enabled": false
+  }
+  // ...
+}
+```
+
+Alternatively, you can set the environment variable `SCARF_ANALYTICS` to `false` as part of the environment that installs your npm packages, e.g., `SCARF_ANALYTICS=false npm install`.

--- a/swagger-editor-dist-package/package.json
+++ b/swagger-editor-dist-package/package.json
@@ -13,6 +13,8 @@
     "Sahar Jafari <shr.jafari@gmail.com>"
   ],
   "license": "Apache-2.0",
-  "dependencies": {},
+  "dependencies": {
+    "@scarf/scarf": "=1.3.0"
+  },
   "devDependencies": {}
 }


### PR DESCRIPTION
## Anonymized analytics

Swagger Editor uses [Scarf](https://scarf.sh/) to collect [anonymized installation analytics](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-what-information-does-scarf-js-send-about-me). These analytics help support the maintainers of this library and ONLY run during installation. To [opt out](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-how-can-i-opt-out-of-analytics), you can set the `scarfSettings.enabled` field to `false` in your project's `package.json`:

```
// package.json
{
  // ...
  "scarfSettings": {
    "enabled": false
  }
  // ...
}
```

Alternatively, you can set the environment variable `SCARF_ANALYTICS` to `false` as part of the environment that installs your npm packages, e.g., `SCARF_ANALYTICS=false npm install`.