### PR TITLE
feat(analytics): use Scarf.js to provide anonymized installation analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ SwaggerEditor is using [**forked** Create React App](https://github.com/swagger-
 
 ## Table of Contents
 
+- [Anonymized analytics](#anonymized-analytics)
 - [Getting started](#getting-started)
   - [Prerequisites](#prerequisites)
   - [Installation](#installation)
@@ -18,6 +19,23 @@ SwaggerEditor is using [**forked** Create React App](https://github.com/swagger-
 - [Docker](#docker)
 - [License](#license)
 - [Software Bill Of Materials (SBOM)](#software-bill-of-materials-sbom)
+
+## Anonymized analytics
+
+Swagger Editor uses [Scarf](https://scarf.sh/) to collect [anonymized installation analytics](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-what-information-does-scarf-js-send-about-me). These analytics help support the maintainers of this library and ONLY run during installation. To [opt out](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-how-can-i-opt-out-of-analytics), you can set the `scarfSettings.enabled` field to `false` in your project's `package.json`:
+
+```
+// package.json
+{
+  // ...
+  "scarfSettings": {
+    "enabled": false
+  }
+  // ...
+}
+```
+
+Alternatively, you can set the environment variable `SCARF_ANALYTICS` to `false` as part of the environment that installs your npm packages, e.g., `SCARF_ANALYTICS=false npm install`.
 
 ## Getting started
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@emotion/styled": "^11.11.5",
         "@mui/material": "^5.15.21",
         "@primer/octicons-react": "^19.10.0",
+        "@scarf/scarf": "=1.3.0",
         "@swagger-api/apidom-core": ">=1.0.0-alpha.3 <1.0.0-beta.0",
         "@swagger-api/apidom-json-pointer": ">=1.0.0-alpha.3 <1.0.0-beta.0",
         "@swagger-api/apidom-ls": ">=1.0.0-alpha.3 <1.0.0-beta.0",
@@ -5835,6 +5836,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.3.2.tgz",
       "integrity": "sha512-V+MvGwaHH03hYhY+k6Ef/xKd6RYlc4q8WBx+2ANmipHJcKuktNcI/NgEsJgdSUF6Lw32njT6OnrRsKYCdgHjYw==",
       "dev": true
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.3.0.tgz",
+      "integrity": "sha512-lHKK8M5CTcpFj2hZDB3wIjb0KAbEOgDmiJGDv1WBRfQgRm/a8/XMEkG/N1iM01xgbUDsPQwi42D+dFo1XPAKew==",
+      "hasInstallScript": true
     },
     "node_modules/@sideway/address": {
       "version": "4.1.4",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@emotion/styled": "^11.11.5",
     "@mui/material": "^5.15.21",
     "@primer/octicons-react": "^19.10.0",
+    "@scarf/scarf": "=1.3.0",
     "@swagger-api/apidom-core": ">=1.0.0-alpha.3 <1.0.0-beta.0",
     "@swagger-api/apidom-json-pointer": ">=1.0.0-alpha.3 <1.0.0-beta.0",
     "@swagger-api/apidom-ls": ">=1.0.0-alpha.3 <1.0.0-beta.0",


### PR DESCRIPTION
## Anonymized analytics

Swagger Editor uses [Scarf](https://scarf.sh/) to collect [anonymized installation analytics](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-what-information-does-scarf-js-send-about-me). These analytics help support the maintainers of this library and ONLY run during installation. To [opt out](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-how-can-i-opt-out-of-analytics), you can set the `scarfSettings.enabled` field to `false` in your project's `package.json`:

```
// package.json
{
  // ...
  "scarfSettings": {
    "enabled": false
  }
  // ...
}
```

Alternatively, you can set the environment variable `SCARF_ANALYTICS` to `false` as part of the environment that installs your npm packages, e.g., `SCARF_ANALYTICS=false npm install`.
