### PR TITLE
fix: Render AsyncAPI 3+ properly with BaseLayout (#5358)

### DIFF
--- a/src/plugins/swagger-ui-adapter/wrap-components/BaseLayout.jsx
+++ b/src/plugins/swagger-ui-adapter/wrap-components/BaseLayout.jsx
@@ -20,7 +20,7 @@ const BaseLayoutWrapper = (Original, system) => {
       );
     }
 
-    if (editorSelectors.selectIsContentTypeAsyncAPI2()) {
+    if (editorSelectors.selectIsContentTypeAsyncAPI()) {
       return <EditorPreviewAsyncAPI />;
     }
 
@@ -36,7 +36,7 @@ const BaseLayoutWrapper = (Original, system) => {
     getComponent: PropTypes.func.isRequired,
     editorSelectors: PropTypes.shape({
       selectIsContentTypeDetectionInProgress: PropTypes.func.isRequired,
-      selectIsContentTypeAsyncAPI2: PropTypes.func.isRequired,
+      selectIsContentTypeAsyncAPI: PropTypes.func.isRequired,
       selectIsContentTypeAPIDesignSystems: PropTypes.func.isRequired,
     }).isRequired,
   };


### PR DESCRIPTION
### Description
Fixing condition in `BaseLayout` to handle properly AsyncAPI 3.x.x.


### Motivation and Context
Rendering AsyncAPI 3.x.x properly with existing layouts.
Fixes #5358 

### How Has This Been Tested?
I ran tests using custom Layout with proposed implementation of BaseLayout.

## Checklist

### My PR contains... 
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
