### PR TITLE
fix(menu): do not stretch menu items to full menu height

### DIFF
--- a/src/standalone/styles/topbar.less
+++ b/src/standalone/styles/topbar.less
@@ -54,9 +54,6 @@
         max-height: 500px;
         flex-wrap: wrap;
         margin: 1.7em 0 0!important;
-        li {
-          flex:22%;
-        }
       }
     }
 
@@ -107,7 +104,7 @@
     vertical-align: text-top;
   }
 }
-  
+
 
 .modal {
   font-family: sans-serif;
@@ -133,7 +130,7 @@
 .modal-message {
   margin: 1.75em 2em;
   font-size: 1.1em;
-  
+
   p {
     line-height: 1.3;
   }

--- a/src/styles/_dropdown-menu.less
+++ b/src/styles/_dropdown-menu.less
@@ -436,10 +436,6 @@
         max-height: 500px;
         flex-wrap: wrap;
         margin: 1.7rem 0 0 !important;
-
-        li {
-          flex: 22%;
-        }
       }
     }
 


### PR DESCRIPTION
Fixes #5490 

### Description
Previously the menu items where evenly spaced inside one column based on a `flex-basis` of 22%. This PR removes this restriction so that the items only take as much height as needed.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
