### PR TITLE
fix(menu): stretch menu list container to fit all items

### DIFF
--- a/src/standalone/styles/topbar.less
+++ b/src/standalone/styles/topbar.less
@@ -47,7 +47,7 @@
     flex-wrap: wrap;
     max-width: 800px;
     .dd-menu-items {
-      width: 700px;
+      width: max-content;
       .dd-items-left {
         display: flex;
         flex-direction: column;

--- a/src/styles/_dropdown-menu.less
+++ b/src/styles/_dropdown-menu.less
@@ -428,7 +428,7 @@
     max-width: 800px;
 
     .dd-menu-items {
-      width: 700px;
+      width: max-content;
 
       .dd-items-left {
         display: flex;


### PR DESCRIPTION
Fixes #5490 

### Description
Fixes an issue where menu items are displayed outside of container
<img width="1381" height="581" alt="Screenshot 2025-10-07 at 10 11 55" src="https://github.com/user-attachments/assets/4bdd65ab-fb43-4eb6-aa14-faaa992fcb11" />


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
