### PR TITLE
fix(ApiDOM): fallback links to an empty array

### DIFF
--- a/src/plugins/editor-monaco-language-apidom/language/providers/DocumentLinkProvider.js
+++ b/src/plugins/editor-monaco-language-apidom/language/providers/DocumentLinkProvider.js
@@ -12,7 +12,7 @@ class DocumentLinkProvider extends Provider {
   }
 
   async provideDocumentLinks(vscodeDocument) {
-    const links = this.#getLinks(vscodeDocument);
+    const links = await this.#getLinks(vscodeDocument);
     const linksWithNonEmptyRanges = links.filter(
       (link) => !this.protocolConverter.asRange(link.range).isEmpty
     );


### PR DESCRIPTION
fixes an issue where apidom crashes in case of getting undefined links