### PR TITLE
ci(release): add step to rename GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,14 +81,14 @@ jobs:
           echo ${{ steps.semantic.outputs.new_release_minor_version }}
           echo ${{ steps.semantic.outputs.new_release_patch_version }}
 
-      - name: Rename GitHub release to "Release – Swagger Editor v<version>"
+      - name: Rename GitHub release
         if: steps.semantic.outputs.new_release_published == 'true'
         uses: actions/github-script@v8
         with:
           script: |
             const version = '${{ steps.semantic.outputs.new_release_version }}';
             const tag = `v${version}`;
-            const releaseName = `Release – Swagger Editor ${tag}`;
+            const releaseName = `Release - Swagger Editor ${tag}`;
             const { data: release } = await github.rest.repos.getReleaseByTag({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -100,7 +100,7 @@ jobs:
               release_id: release.id,
               name: releaseName
             });
-            core.info(`Renamed release ${tag} → "${releaseName}"`);
+            core.info(`Renamed release ${tag} -> "${releaseName}"`);
 
       - name: Prepare released version for uploading
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,27 @@ jobs:
           echo ${{ steps.semantic.outputs.new_release_minor_version }}
           echo ${{ steps.semantic.outputs.new_release_patch_version }}
 
+      - name: Rename GitHub release to "Release – Swagger Editor v<version>"
+        if: steps.semantic.outputs.new_release_published == 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const version = '${{ steps.semantic.outputs.new_release_version }}';
+            const tag = `v${version}`;
+            const releaseName = `Release – Swagger Editor ${tag}`;
+            const { data: release } = await github.rest.repos.getReleaseByTag({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag
+            });
+            await github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: release.id,
+              name: releaseName
+            });
+            core.info(`Renamed release ${tag} → "${releaseName}"`);
+
       - name: Prepare released version for uploading
         shell: bash
         run: |


### PR DESCRIPTION
Adds a step to rename the GitHub release with the new version format.