### PR TITLE
feat: add toggle to omit optional request body in Try It Out

### DIFF
--- a/src/plugins/editor-preview-swagger-ui/components/RequestBodyWrapper.jsx
+++ b/src/plugins/editor-preview-swagger-ui/components/RequestBodyWrapper.jsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+
+const RequestBodyWrapper = (Original) => {
+  const RequestBody = ({ requestBody, isExecute, onChange, ...restProps }) => {
+    const { onChangeIncludeEmpty } = restProps;
+    const isRequired = requestBody && requestBody.get('required') === true;
+    const isActive = isExecute || restProps.tryItOutEnabled;
+    const showToggle = !isRequired && isActive;
+
+    const [includeBody, setIncludeBody] = useState(true);
+
+    const handleToggle = (e) => {
+      const { checked } = e.target;
+      setIncludeBody(checked);
+
+      if (!checked) {
+        if (typeof onChange === 'function') {
+          onChange(undefined);
+        }
+        if (typeof onChangeIncludeEmpty === 'function') {
+          onChangeIncludeEmpty(false);
+        }
+      } else if (typeof onChangeIncludeEmpty === 'function') {
+        onChangeIncludeEmpty(true);
+      }
+    };
+
+    return (
+      <div className="swagger-editor__request-body-wrapper">
+        {showToggle && (
+          <label htmlFor="request-body-toggle" className="swagger-editor__request-body-toggle">
+            <input
+              id="request-body-toggle"
+              type="checkbox"
+              checked={includeBody}
+              onChange={handleToggle}
+            />
+            <span>Send request body</span>
+          </label>
+        )}
+        {(!showToggle || includeBody) && (
+          <Original
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...restProps}
+            requestBody={requestBody}
+            isExecute={isExecute}
+            onChange={onChange}
+          />
+        )}
+      </div>
+    );
+  };
+
+  RequestBody.propTypes = {
+    requestBody: ImmutablePropTypes.map,
+    isExecute: PropTypes.bool,
+    tryItOutEnabled: PropTypes.bool,
+    onChange: PropTypes.func,
+    onChangeIncludeEmpty: PropTypes.func,
+  };
+
+  RequestBody.defaultProps = {
+    requestBody: null,
+    isExecute: false,
+    tryItOutEnabled: false,
+    onChange: () => {},
+    onChangeIncludeEmpty: () => {},
+  };
+
+  return RequestBody;
+};
+
+export default RequestBodyWrapper;

--- a/src/plugins/editor-preview-swagger-ui/index.js
+++ b/src/plugins/editor-preview-swagger-ui/index.js
@@ -1,6 +1,7 @@
 import EditorPreviewSwaggerUI from './components/EditorPreviewSwaggerUI/EditorPreviewSwaggerUI.jsx';
 import JumpToPath from './components/JumpToPath.jsx';
 import EditorPreviewWrapper from './extensions/editor-preview/wrap-components/EditorPreviewWrapper.jsx';
+import RequestBodyWrapper from './components/RequestBodyWrapper.jsx';
 import { previewUnmounted } from './actions/preview-unmounted.js';
 import {
   jumpToPath,
@@ -23,6 +24,7 @@ const EditorPreviewSwaggerUIPlugin = () => ({
   },
   wrapComponents: {
     EditorPreview: EditorPreviewWrapper,
+    RequestBody: RequestBodyWrapper,
   },
   statePlugins: {
     editor: {
@@ -33,7 +35,6 @@ const EditorPreviewSwaggerUIPlugin = () => ({
     editorPreviewSwaggerUI: {
       actions: {
         previewUnmounted,
-
         jumpToPath,
         jumpToPathStarted,
         jumpToPathSuccess,


### PR DESCRIPTION
## Summary

This PR does the following:
- Adds a `RequestBodyWrapper` component that wraps swagger-ui's
  `RequestBody` component via `wrapComponents`
- Shows a **"Send request body"** checkbox in Try It Out mode
  when `requestBody.required` is `false` or not set
- When unchecked, no body and no `Content-Type` header is sent
  in the actual HTTP request
- When checked (default), existing behavior is fully preserved

Closes #4807

## Behavior

| Scenario | Checkbox visible | Result |
|---|---|---|
| `required: false` + checkbox **checked** (default) | ✅ Yes | Body sent normally — no change for existing users |
| `required: false` + checkbox **unchecked** | ✅ Yes | No body, no `Content-Type` header sent |
| `required: true` | ❌ No | Checkbox never appears — existing behavior unchanged |

## Files changed
- `src/plugins/editor-preview-swagger-ui/components/RequestBodyWrapper.jsx` ← new file
- `src/plugins/editor-preview-swagger-ui/index.js` ← registers `RequestBody` wrapComponent

## How to test

### Setup
Paste the following YAML into the editor:

```yaml
openapi: 3.1.0
info:
  title: One game API
  version: "1.0"
servers:
  - url: http://127.0.0.1:8000
    description: Local development server
paths:
  /v2/auth:
    post:
      summary: Create an authorization token (optional body)
      operationId: createAuthV2
      requestBody:
        content:
          application/json:
            schema:
              type: object
              properties:
                email:
                  type: string
        required: false
      responses:
        "200":
          description: Authorization token created
  /v2/auth/required:
    post:
      summary: Create an authorization token (required body)
      operationId: createAuthV2Required
      requestBody:
        content:
          application/json:
            schema:
              type: object
              properties:
                email:
                  type: string
        required: true
      responses:
        "200":
          description: Authorization token created
```

---

### Test 1 — Optional body, checkbox unchecked (main feature)
1. Click **Try it out** on `POST /v2/auth`
2. Confirm the **"Send request body"** checkbox appears ✅
3. **Uncheck** the checkbox → body textarea disappears
4. Click **Execute**
5. Open **DevTools → Network tab** → click the request
6. Go to **Headers** → confirm **no `Content-Type: application/json`** ✅
7. Confirm **Request Payload section does not appear** ✅

---

### Test 2 — Optional body, checkbox checked (default behavior preserved)
1. Click **Try it out** on `POST /v2/auth`
2. Leave checkbox **checked** (default)
3. Click **Execute**
4. Open **DevTools → Network tab** → click the request
5. Confirm **`Content-Type: application/json` header is present** ✅
6. Confirm **Request Payload section shows the JSON body** ✅

---

### Test 3 — Required body (no regression)
1. Click **Try it out** on `POST /v2/auth/required`
2. Confirm **no checkbox appears** — only the body textarea ✅
3. Existing behavior is completely unchanged ✅