### PR TITLE
fix(build): prevent CI absolute path in ESM swagger-ui.css import

### DIFF
--- a/vite.config.esm.js
+++ b/vite.config.esm.js
@@ -54,8 +54,12 @@ export const mainConfig = defineConfig({
       // isResolved — true only after Vite has resolved the path; bare specifiers
       //              arrive here with isResolved:false and their original form.
       external: (id, _importer, isResolved) => {
-        // Keep swagger-ui CSS bundled (side-effect import)
+        // Keep swagger-ui CSS bundled — guard both the bare specifier and the resolved
+        // absolute path, otherwise the node_modules safety net below externalizes it
+        // causing the CI runner's absolute path to be baked into the built ESM file
         if (id === 'swagger-ui-react/swagger-ui.css') return false;
+        if (isResolved && id.includes('swagger-ui-react') && id.endsWith('swagger-ui.css'))
+          return false;
         // Rollup checks external() BEFORE calling resolveId hooks for bare specifiers.
         // Allow ?worker imports through so rewriteEditorWorkerImport can intercept them.
         if (id.endsWith('?worker')) return false;


### PR DESCRIPTION
## Summary

- The `external()` function in `vite.config.esm.js` was guarding only the bare specifier form of `swagger-ui-react/swagger-ui.css`
- Rollup calls `external()` a second time with the resolved absolute path (`isResolved: true`), which caused the node_modules safety net to externalize it with the CI runner's machine-specific absolute path (e.g. `/home/runner/work/swagger-editor/.../swagger-ui.css`)
- That absolute path was then written verbatim into `dist/esm/swagger-editor.js`, breaking the package for consumers
- Added a second guard for the resolved absolute path form to prevent this

## Test plan

- [x] Run `npm run build:bundle:esm` and verify `dist/esm/swagger-editor.js` does not contain an absolute path import for `swagger-ui.css`
- [x] Verify `swagger-ui-react/swagger-ui.css` styles are still included in the ESM output

🤖 Generated with [Claude Code](https://claude.com/claude-code)