### PR TITLE
fix(editor-monaco-language-apidom): webpack ignore comment to dynamic import

### DIFF
--- a/src/plugins/editor-monaco-language-apidom/language/ApiDOMWorker.js
+++ b/src/plugins/editor-monaco-language-apidom/language/ApiDOMWorker.js
@@ -165,7 +165,7 @@ export const makeCreate = (BaseClass) => (ctx, createData) => {
           continue;
         }
         // eslint-disable-next-line no-await-in-loop
-        const mod = await import(/* @vite-ignore */ path);
+        const mod = await import(/* webpackIgnore: true */ /* @vite-ignore */ path);
         const factory = mod.customApiDOMWorkerFactory ?? globalThis.customApiDOMWorkerFactory;
         if (typeof factory !== 'function') {
           throw new TypeError(`The module at ${path} does not export customApiDOMWorkerFactory`);


### PR DESCRIPTION
 - Adds `/* webpackIgnore: true */` alongside the existing `/* @vite-ignore */` comment on the dynamic `import()` call in `ApiDOMWorker.js`
 - Ensures bundlers using webpack (or webpack-compatible toolchains) skip static analysis of this runtime-resolved path, matching the existing Vite behaviour